### PR TITLE
Add functions to removes all commands.

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -169,7 +169,7 @@ class SlashCommand:
 
     async def remove_all_commands(self):
         """
-        Remove all slash commands except subcommands to Discord API.
+        Remove all slash commands.
         """
 
         await self.remove_all_commands_in('global')
@@ -181,7 +181,7 @@ class SlashCommand:
 
     async def remove_all_commands_in(self, area):
         """
-        Remove all slash commands in area except subcommands to Discord API.
+        Remove all slash commands in area.
 
         :param area: 'global' or guild ID where removing all commands.
         :type area: Union[str, int]

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 from . import http
 from . import model
+from . import error
 from .utils import manage_commands
 from inspect import iscoroutinefunction
 
@@ -165,6 +166,47 @@ class SlashCommand:
                                                         selected.description,
                                                         selected.options)
         self.logger.info("Completed registering all commands!")
+
+    async def remove_all_commands(self):
+        """
+        Remove all slash commands except subcommands to Discord API.
+        """
+
+        await self.remove_all_commands_in('global')
+
+        for guild in self._discord.guilds:
+            try: await self.remove_all_commands_in(guild.id)
+            except error.RequestFailure:
+                pass
+
+    async def remove_all_commands_in(self, area):
+        """
+        Remove all slash commands in area except subcommands to Discord API.
+
+        :param area: 'global' or guild ID where removing all commands.
+        :type area: Union[str, int]
+        """
+        await self._discord.wait_until_ready()  # In case commands are still not registered to SlashCommand.
+
+        self.logger.info("Removing commands...")
+
+        for x in self.commands.keys():
+
+            commands = await manage_commands.get_all_commands(
+                self._discord.user.id,
+                self._discord.http.token,
+                None if area == 'global' else area
+            )
+
+            for command in commands:
+                await manage_commands.remove_slash_command(
+                    self._discord.user.id,
+                    self._discord.http.token,
+                    None if area == 'global' else area,
+                    command['id']
+                )
+
+        self.logger.info("Completed removing all commands !")
 
     def add_slash_command(self,
                           cmd,

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -190,21 +190,19 @@ class SlashCommand:
 
         self.logger.info("Removing commands...")
 
-        for x in self.commands.keys():
+        commands = await manage_commands.get_all_commands(
+            self._discord.user.id,
+            self._discord.http.token,
+            None if area == 'global' else area
+        )
 
-            commands = await manage_commands.get_all_commands(
+        for command in commands:
+            await manage_commands.remove_slash_command(
                 self._discord.user.id,
                 self._discord.http.token,
-                None if area == 'global' else area
+                None if area == 'global' else area,
+                command['id']
             )
-
-            for command in commands:
-                await manage_commands.remove_slash_command(
-                    self._discord.user.id,
-                    self._discord.http.token,
-                    None if area == 'global' else area,
-                    command['id']
-                )
 
         self.logger.info("Completed removing all commands !")
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -167,45 +167,6 @@ class SlashCommand:
                                                         selected.options)
         self.logger.info("Completed registering all commands!")
 
-    async def remove_all_commands(self):
-        """
-        Remove all slash commands.
-        """
-
-        await self.remove_all_commands_in('global')
-
-        for guild in self._discord.guilds:
-            try: await self.remove_all_commands_in(guild.id)
-            except error.RequestFailure:
-                pass
-
-    async def remove_all_commands_in(self, area):
-        """
-        Remove all slash commands in area.
-
-        :param area: 'global' or guild ID where removing all commands.
-        :type area: Union[str, int]
-        """
-        await self._discord.wait_until_ready()  # In case commands are still not registered to SlashCommand.
-
-        self.logger.info("Removing commands...")
-
-        commands = await manage_commands.get_all_commands(
-            self._discord.user.id,
-            self._discord.http.token,
-            None if area == 'global' else area
-        )
-
-        for command in commands:
-            await manage_commands.remove_slash_command(
-                self._discord.user.id,
-                self._discord.http.token,
-                None if area == 'global' else area,
-                command['id']
-            )
-
-        self.logger.info("Completed removing all commands !")
-
     def add_slash_command(self,
                           cmd,
                           name: str = None,

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -93,6 +93,52 @@ async def get_all_commands(bot_id,
             return await resp.json()
 
 
+async def remove_all_commands(slash):
+    """
+    Remove all slash commands.
+
+    :param slash: Instance of SlashCommand.
+    :type slash: SlashCommand
+    """
+
+    await remove_all_commands_in(slash, 'global')
+
+    for guild in slash._discord.guilds:
+        try: await remove_all_commands_in(slash, guild.id)
+        except RequestFailure:
+            pass
+
+
+async def remove_all_commands_in(slash, area):
+    """
+    Remove all slash commands in area.
+
+    :param slash: Instance of SlashCommand.
+    :type slash: SlashCommand
+    :param area: 'global' or guild ID where removing all commands.
+    :type area: Union[str, int]
+    """
+    await slash._discord.wait_until_ready()  # In case commands are still not registered to SlashCommand.
+
+    slash.logger.info("Removing commands...")
+
+    commands = await get_all_commands(
+        slash._discord.user.id,
+        slash._discord.http.token,
+        None if area == 'global' else area
+    )
+
+    for command in commands:
+        await remove_slash_command(
+            slash._discord.user.id,
+            slash._discord.http.token,
+            None if area == 'global' else area,
+            command['id']
+        )
+
+    slash.logger.info("Completed removing all commands !")
+
+
 def create_option(name: str,
                   description: str,
                   option_type: int,


### PR DESCRIPTION
Hello !  
  
I made two functions to delete all commands everywhere or just in one area (global or guild).  

### Why ?
I did this because I wanted to delete all the commands from a server and then put back only the ones I wanted, so that I could remove the ones that no longer exist and add the new ones.  
  
### Exemple :
```python
import discord
import discord_slash


bot = discord.Client()
slash = discord_slash.SlashCommand(bot)

@bot.event
async def on_ready(self):

    await slash.remove_all_commands()

    # Useless, because `remove_all_commands` already removes the global commands,
    #  just for the exemple.
    await slash.remove_all_commands_in('global')

    # As explained I then call up the existing `register_all_commands` function 
    #  to add the commands I want.
    await slash.register_all_commands()

bot.run(token)
```

Thank you for reading, have a nice day !