### PR TITLE
New enumeration, SlashCommandOptionType

### DIFF
--- a/discord_slash/__init__.py
+++ b/discord_slash/__init__.py
@@ -9,7 +9,7 @@ Simple Discord Slash Command extension for discord.py
 """
 
 from .client import SlashCommand
-from .client import SlashCommandOptionType
+from .model import SlashCommandOptionType
 from .model import SlashContext
 from .utils import manage_commands
 

--- a/discord_slash/__init__.py
+++ b/discord_slash/__init__.py
@@ -9,6 +9,7 @@ Simple Discord Slash Command extension for discord.py
 """
 
 from .client import SlashCommand
+from .client import SlashCommandOptionType
 from .model import SlashContext
 from .utils import manage_commands
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -7,6 +7,7 @@ from . import http
 from . import model
 from . import error
 from .utils import manage_commands
+from enum import IntEnum
 
 
 class SlashCommand:
@@ -427,9 +428,10 @@ class SlashCommand:
 
         .. code-block:: python
 
-            {"option_role": "role",       # For key put name of the option and for value put type of the option.
-             "option_user": 6,            # Also can use number for type
-             "option_channel": "CHANNEL"} # and all upper case.
+            {"option_role": "role",                      # For key put name of the option and for value put type of the option.
+             "option_user": SlashCommandOptionType.USER, # Also can use an enumeration member for the type
+             "option_user_two": 6,                       # or number
+             "option_channel": "CHANNEL"}                # or upper case string.
 
         :param name: Name of the slash command. Default name of the coroutine.
         :type name: str
@@ -565,15 +567,15 @@ class SlashCommand:
         types = {
             "user": 0,
             "USER": 0,
-            6: 0,
+            SlashCommandOptionType.USER: 0,
             "6": 0,
             "channel": 1,
             "CHANNEL": 1,
-            7: 1,
+            SlashCommandOptionType.CHANNEL: 1,
             "7": 1,
             "role": 2,
             "ROLE": 2,
-            8: 2,
+            SlashCommandOptionType.ROLE: 2,
             "8": 2
         }
 
@@ -731,3 +733,17 @@ class SlashCommand:
             return
         # Prints exception if not overrided or has no listener for error.
         self.logger.exception(f"An exception has occurred while executing command `{ctx.name}`:")
+
+
+class SlashCommandOptionType(IntEnum):
+    """
+    Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.
+    """
+    SUB_COMMAND = 1
+    SUB_COMMAND_GROUP = 2
+    STRING = 3
+    INTEGER = 4
+    BOOLEAN = 5
+    USER = 6
+    CHANNEL = 7
+    ROLE = 8

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -7,7 +7,6 @@ from . import http
 from . import model
 from . import error
 from .utils import manage_commands
-from enum import IntEnum
 
 
 class SlashCommand:
@@ -733,17 +732,3 @@ class SlashCommand:
             return
         # Prints exception if not overrided or has no listener for error.
         self.logger.exception(f"An exception has occurred while executing command `{ctx.name}`:")
-
-
-class SlashCommandOptionType(IntEnum):
-    """
-    Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.
-    """
-    SUB_COMMAND = 1
-    SUB_COMMAND_GROUP = 2
-    STRING = 3
-    INTEGER = 4
-    BOOLEAN = 5
-    USER = 6
-    CHANNEL = 7
-    ROLE = 8

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -3,6 +3,7 @@ import discord
 from discord.ext import commands
 from . import http
 from . import error
+from enum import IntEnum
 
 
 class SlashContext:
@@ -282,3 +283,17 @@ class CogSubcommandObject(SubcommandObject):
         :return: Coroutine
         """
         return self.func(self.cog, *args)
+
+
+class SlashCommandOptionType(IntEnum):
+    """
+    Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.
+    """
+    SUB_COMMAND = 1
+    SUB_COMMAND_GROUP = 2
+    STRING = 3
+    INTEGER = 4
+    BOOLEAN = 5
+    USER = 6
+    CHANNEL = 7
+    ROLE = 8

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -72,6 +72,7 @@ Let's do some more complicated things:
 
     import discord
     from discord_slash import SlashCommand
+    from discord_slash import SlashCommandOptionType
     from discord_slash.utils import manage_commands
 
     client = discord.Client(intents=discord.Intents.all())
@@ -87,7 +88,7 @@ Let's do some more complicated things:
     async def _ping(ctx):
         await ctx.send(content=f"Pong! ({client.latency*1000}ms)")
 
-    @slash.slash(name="echo", guild_ids=guild_ids, options=[manage_commands.create_option("string", "A random string.", 3, True)])
+    @slash.slash(name="echo", guild_ids=guild_ids, options=[manage_commands.create_option("string", "A random string.", SlashCommandOptionType.STRING, True)])
     async def _echo(ctx, string):
         await ctx.send(content=string)
 


### PR DESCRIPTION
This is the equivalent of [ApplicationCommandOptionType](https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype) in the Discord API.  Having this means the programmer doesnʼt have to remember which integer refers to which type.