### PR TITLE
Added auto-generation of command options (+ fixes)

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -286,7 +286,7 @@ class SlashCommand:
         :type auto_convert: dict
         :param guild_ids: List of Guild ID of where the command will be used. Default ``None``, which will be global command.
         :type guild_ids: List[int]
-        :param options: Options of the slash command.
+        :param options: Options of the slash command. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
         :type options: list
         :param has_subcommands: Whether it has subcommand. Default ``False``.
         :type has_subcommands: bool
@@ -303,7 +303,10 @@ class SlashCommand:
         description = description or getdoc(cmd) or "No description"
 
         if options is None:
-            options = manage_commands.create_options_from_args(cmd, description)
+            options = manage_commands.generate_options(cmd, description)
+
+        if options:
+            auto_convert = manage_commands.generate_auto_convert(options)
 
         _cmd = {
             "func": cmd,
@@ -348,7 +351,7 @@ class SlashCommand:
         :type auto_convert: dict
         :param guild_ids: List of guild ID of where the command will be used. Default ``None``, which will be global command.
         :type guild_ids: List[int]
-        :param options: Options of the subcommand.
+        :param options: Options of the subcommand. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
         :type options: list
         """
         base = base.lower()
@@ -358,7 +361,10 @@ class SlashCommand:
         description = description or getdoc(cmd) or "No description"
 
         if options is None:
-            options = manage_commands.create_options_from_args(cmd, description)
+            options = manage_commands.generate_options(cmd, description)
+
+        if options:
+            auto_convert = manage_commands.generate_auto_convert(options)
 
         _cmd = {
             "func": None,
@@ -457,18 +463,9 @@ class SlashCommand:
         :param options: Options of the slash command. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
         :type options: List[dict]
         """
-
         if guild_id:
             self.logger.warning("`guild_id` is deprecated! `Use guild_ids` instead.")
             guild_ids = [guild_id]
-
-        if options:
-            # Overrides original auto_convert.
-            auto_convert = {}
-            for x in options:
-                if x["type"] in (model.SlashCommandOptionType.SUB_COMMAND, model.SlashCommandOptionType.SUB_COMMAND_GROUP):
-                    raise Exception("Please use `subcommand()` decorator for subcommands!")
-                auto_convert[x["name"]] = x["type"]
 
         def wrapper(cmd):
             self.add_slash_command(cmd, name, description, auto_convert, guild_ids, options)
@@ -532,15 +529,6 @@ class SlashCommand:
         :param options: Options of the subcommand. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
         :type options: List[dict]
         """
-
-        if options:
-            # Overrides original auto_convert.
-            auto_convert = {}
-            for x in options:
-                if x["type"] in (model.SlashCommandOptionType.SUB_COMMAND, model.SlashCommandOptionType.SUB_COMMAND_GROUP):
-                    raise Exception("You can't use subcommand or subcommand_group type!")
-                auto_convert[x["name"]] = x["type"]
-
         base_description = base_description if base_description else base_desc
         subcommand_group_description = subcommand_group_description if subcommand_group_description else sub_group_desc
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -170,7 +170,7 @@ class SlashCommand:
                         _dict = {
                             "name": sub.name,
                             "description": sub.description if sub.description else "No Description.",
-                            "type": 1,
+                            "type": model.SlashCommandOptionType.SUB_COMMAND,
                             "options": sub.options if sub.options else []
                         }
                         options.append(_dict)
@@ -178,7 +178,7 @@ class SlashCommand:
                         base_dict = {
                             "name": y,
                             "description": "No Description.",
-                            "type": 2,
+                            "type": model.SlashCommandOptionType.SUB_COMMAND_GROUP,
                             "options": []
                         }
                         for z in sub:
@@ -186,7 +186,7 @@ class SlashCommand:
                             _dict = {
                                 "name": sub_sub.name,
                                 "description": sub_sub.description if sub_sub.description else "No Description.",
-                                "type": 1,
+                                "type": model.SlashCommandOptionType.SUB_COMMAND,
                                 "options": sub_sub.options if sub_sub.options else []
                             }
                             base_dict["options"].append(_dict)
@@ -300,15 +300,17 @@ class SlashCommand:
             has_subcommands = tgt.has_subcommands
             guild_ids += tgt.allowed_guild_ids
 
-        if not description:
-            description = getdoc(cmd)
+        description = description or getdoc(cmd) or "No description"
+
+        if options is None:
+            options = manage_commands.create_options_from_args(cmd, description)
 
         _cmd = {
             "func": cmd,
-            "description": description if description else "No description.",
+            "description": description,
             "auto_convert": auto_convert,
             "guild_ids": guild_ids,
-            "api_options": options if options else [],
+            "api_options": options,
             "has_subcommands": has_subcommands
         }
         self.commands[name] = model.CommandObject(name, _cmd)
@@ -353,12 +355,14 @@ class SlashCommand:
         subcommand_group = subcommand_group.lower() if subcommand_group else subcommand_group
         name = cmd.__name__ if not name else name
         name = name.lower()
-        if not description:
-            description = getdoc(cmd)
+        description = description or getdoc(cmd) or "No description"
+
+        if options is None:
+            options = manage_commands.create_options_from_args(cmd, description)
 
         _cmd = {
             "func": None,
-            "description": base_description if base_description else "No Description.",
+            "description": base_description or "No Description.",
             "auto_convert": {},
             "guild_ids": guild_ids,
             "api_options": [],
@@ -367,12 +371,12 @@ class SlashCommand:
         _sub = {
             "func": cmd,
             "name": name,
-            "description": description if description else "No Description.",
-            "base_desc": base_description if base_description else "No Description.",
-            "sub_group_desc": subcommand_group_description if subcommand_group_description else "No Description.",
+            "description": description,
+            "base_desc": base_description or "No Description.",
+            "sub_group_desc": subcommand_group_description or "No Description.",
             "auto_convert": auto_convert,
             "guild_ids": guild_ids,
-            "api_options": options if options else []
+            "api_options": options
         }
         if base not in self.commands:
             self.commands[base] = model.CommandObject(base, _cmd)
@@ -462,7 +466,7 @@ class SlashCommand:
             # Overrides original auto_convert.
             auto_convert = {}
             for x in options:
-                if x["type"] < 3:
+                if x["type"] in (model.SlashCommandOptionType.SUB_COMMAND, model.SlashCommandOptionType.SUB_COMMAND_GROUP):
                     raise Exception("Please use `subcommand()` decorator for subcommands!")
                 auto_convert[x["name"]] = x["type"]
 
@@ -533,7 +537,7 @@ class SlashCommand:
             # Overrides original auto_convert.
             auto_convert = {}
             for x in options:
-                if x["type"] < 3:
+                if x["type"] in (model.SlashCommandOptionType.SUB_COMMAND, model.SlashCommandOptionType.SUB_COMMAND_GROUP):
                     raise Exception("You can't use subcommand or subcommand_group type!")
                 auto_convert[x["name"]] = x["type"]
 

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -1,5 +1,5 @@
 import typing
-from .model import CogCommandObject, CogSubcommandObject
+from .model import CogCommandObject, CogSubcommandObject, SlashCommandOptionType
 
 
 def cog_slash(*,
@@ -46,7 +46,7 @@ def cog_slash(*,
         # Overrides original auto_convert.
         auto_convert = {}
         for x in options:
-            if x["type"] < 3:
+            if x["type"] in (SlashCommandOptionType.SUB_COMMAND, SlashCommandOptionType.SUB_COMMAND_GROUP):
                 raise Exception("Please use `cog_subcommand()` decorator for cog subcommands!")
             auto_convert[x["name"]] = x["type"]
 
@@ -119,12 +119,11 @@ def cog_subcommand(*,
     :param options: Options of the subcommand. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
     :type options: List[dict]
     """
-
     if options:
         # Overrides original auto_convert.
         auto_convert = {}
         for x in options:
-            if x["type"] < 3:
+            if x["type"] in (SlashCommandOptionType.SUB_COMMAND, SlashCommandOptionType.SUB_COMMAND_GROUP):
                 raise Exception("You can't use subcommand or subcommand_group type!")
             auto_convert[x["name"]] = x["type"]
 

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -44,20 +44,15 @@ def cog_slash(*,
     :param options: Options of the slash command. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
     :type options: List[dict]
     """
-    if options:
-        # Overrides original auto_convert.
-        auto_convert = {}
-        for x in options:
-            if x["type"] in (SlashCommandOptionType.SUB_COMMAND, SlashCommandOptionType.SUB_COMMAND_GROUP):
-                raise Exception("Please use `cog_subcommand()` decorator for cog subcommands!")
-            auto_convert[x["name"]] = x["type"]
-
     def wrapper(cmd):
         desc = description or inspect.getdoc(cmd) or "No description"
         if options is None:
-            opts = manage_commands.create_options_from_args(cmd, desc)
+            opts = manage_commands.generate_options(cmd, desc)
         else:
             opts = options
+
+        if opts:
+            auto_convert = manage_commands.generate_auto_convert(opts)
 
         _cmd = {
             "func": cmd,
@@ -127,23 +122,18 @@ def cog_subcommand(*,
     :param options: Options of the subcommand. This will affect ``auto_convert`` and command data at Discord API. Default ``None``.
     :type options: List[dict]
     """
-    if options:
-        # Overrides original auto_convert.
-        auto_convert = {}
-        for x in options:
-            if x["type"] in (SlashCommandOptionType.SUB_COMMAND, SlashCommandOptionType.SUB_COMMAND_GROUP):
-                raise Exception("You can't use subcommand or subcommand_group type!")
-            auto_convert[x["name"]] = x["type"]
-
     base_description = base_description or base_desc
     subcommand_group_description = subcommand_group_description or sub_group_desc
 
     def wrapper(cmd):
         desc = description or inspect.getdoc(cmd) or "No description"
         if options is None:
-            opts = manage_commands.create_options_from_args(cmd, desc)
+            opts = manage_commands.generate_options(cmd, desc)
         else:
             opts = options
+
+        if opts:
+            auto_convert = manage_commands.generate_auto_convert(opts)
 
         _sub = {
             "func": cmd,

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -1,6 +1,6 @@
 import typing
 import inspect
-from .model import CogCommandObject, CogSubcommandObject, SlashCommandOptionType
+from .model import CogCommandObject, CogSubcommandObject
 from .utils import manage_commands
 
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -90,10 +90,11 @@ class SlashContext:
         :type complete_hidden: bool
         :return: ``None``
         """
-        if not isinstance(embeds, list):
-            raise error.IncorrectFormat("Provide a list of embeds.")
-        elif len(embeds) > 10:
-            raise error.IncorrectFormat("Do not provide more than 10 embeds.")
+        if embeds is not None:
+            if not isinstance(embeds, list):
+                raise error.IncorrectFormat("Provide a list of embeds.")
+            elif len(embeds) > 10:
+                raise error.IncorrectFormat("Do not provide more than 10 embeds.")
 
         if complete_hidden:
             # Overrides both `hidden` and `send_type`.
@@ -299,3 +300,18 @@ class SlashCommandOptionType(IntEnum):
     USER = 6
     CHANNEL = 7
     ROLE = 8
+
+    @classmethod
+    def from_type(cls, t: type):
+        """
+        Get a specific SlashCommandOptionType from a type (or object).
+
+        :param t: The type or object to get a SlashCommandOptionType for.
+        :return: :class:`.model.SlashCommandOptionType` or ``None``
+        """
+        if issubclass(t, str): return cls.STRING
+        if issubclass(t, int): return cls.INTEGER
+        if issubclass(t, bool): return cls.BOOLEAN
+        if issubclass(t, discord.abc.User): return cls.USER
+        if issubclass(t, discord.abc.GuildChannel): return cls.CHANNEL
+        if issubclass(t, discord.abc.Role): return cls.ROLE

--- a/discord_slash/utils/__init__.py
+++ b/discord_slash/utils/__init__.py
@@ -4,6 +4,6 @@ discord-py-slash-command.utils
 
 Utility functions for slash command.
 
-:copyright: (c) 2020 eunwoo1104
+:copyright: (c) 2020-2021 eunwoo1104
 :license: MIT
 """

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -165,9 +165,9 @@ def create_option(name: str,
     }
 
 
-def create_options_from_args(function: Callable, description: str = "No description.") -> list:
+def generate_options(function: Callable, description: str = "No description.") -> list:
     """
-    Creates a list of options from the type hints of a command.
+    Generates a list of options from the type hints of a command.
     You currently can type hint: str, int, bool, discord.User, discord.Channel, discord.Role
 
     .. warning::
@@ -192,6 +192,24 @@ def create_options_from_args(function: Callable, description: str = "No descript
         options.append(create_option(argument, description, option_type, required))
 
     return options
+
+
+def generate_auto_convert(options: list) -> dict:
+    """
+    Generate an auto_convert dict from command options.
+
+    .. note::
+        This is automatically used if you pass options.
+
+    :param options: The list of options.
+    """
+    auto_convert = {}
+    for x in options:
+        if x["type"] in (SlashCommandOptionType.SUB_COMMAND, SlashCommandOptionType.SUB_COMMAND_GROUP):
+            raise Exception("You can't use subcommand or subcommand_group type!")
+        auto_convert[x["name"]] = x["type"]
+
+    return auto_convert
 
 
 def create_choice(value: str, name: str):

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -2,6 +2,8 @@ import typing
 import asyncio
 import aiohttp
 from ..error import RequestFailure
+from ..model import SlashCommandOptionType
+from collections.abc import Callable
 
 
 async def add_slash_command(bot_id,
@@ -161,6 +163,35 @@ def create_option(name: str,
         "required": required,
         "choices": choices if choices else []
     }
+
+
+def create_options_from_args(function: Callable, description: str = "No description.") -> list:
+    """
+    Creates a list of options from the type hints of a command.
+    You currently can type hint: str, int, bool, discord.User, discord.Channel, discord.Role
+
+    .. warning::
+        This is automatically used if you do not pass any options directly. It is not recommended to use this.
+
+    :param function: The function callable of the command.
+    :param description: The default argument description.
+    """
+    options = []
+    for i, (argument, hint) in enumerate(typing.get_type_hints(function).items()):
+        if i == 0:  # First element is ctx
+            continue
+
+        required = True
+        if typing.get_origin(hint) is typing.Union:
+            # Make a command argument optional with typing.Optional[type] or typing.Union[type, None]
+            args = typing.get_args(hint)
+            hint = args[0]
+            required = not args[-1] is type(None)
+
+        option_type = SlashCommandOptionType.from_type(hint)  # If no type hint is passed, then defaults to string
+        options.append(create_option(argument, description, option_type, required))
+
+    return options
 
 
 def create_choice(value: str, name: str):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'discord-py-slash-command'
-copyright = '2020, eunwoo1104'
+copyright = '2020-2021, eunwoo1104'
 author = 'eunwoo1104'
 
 


### PR DESCRIPTION
# Description

Added auto-generation of command options. This works through argument type hints (similar behavior to [discord.py's converters](https://discordpy.readthedocs.io/en/latest/ext/commands/commands.html?highlight=converters#converters))
This feature is a fallback if no options are passed directly. Note that the choices option and individual description for arguments are currently not supported.

Additional changes:
- Now SlashCommandOptionType is used more often instead of numbers
- using "or" clause instead of "var1 if var1 else var2"
- Adding conversion of type (hints) to SlashCommandOptionType if possible
- Fixing: IncorrectFormat would be raised if no embeds were passed
- Updating copyright year
- Auto description is now available for cog_ext
- Create a function for the generation of auto_dict from options

# Usage

```py
@slash.slash()
async def mention(ctx: SlashContext, user: discord.User, message: typing.Optional[str] = ""):
    """Mention a given user with an optional message"""
    await ctx.send(content=f"{user.mention} {message}")
```

![image](https://user-images.githubusercontent.com/43505515/104106905-10402a00-52b9-11eb-985d-78ecfd2d15f5.png)

# Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update