### PR TITLE
New front page change to docs.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to discord-py-slash-command's official documentation!
-====================================================
+=============================================================
 
 discord-py-slash-command is a simple discord.py library extension
 for using Discord's new Slash Command feature.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,44 +3,30 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to discord-py-slash-command's documentation!
+Welcome to discord-py-slash-command's official documentation!
 ====================================================
 
-discord-py-slash-command is simple discord.py extension
-for using Discord's Slash Command feature.
+discord-py-slash-command is a simple discord.py library extension
+for using Discord's new Slash Command feature.
 
-Example:
+Before going into the advanced sections that guide you through
+added more complex stuff documentation-wise, it is highly recommended
+to check out the `quickstart`_ page first from here or below in the contents.
 
-.. code-block:: python
+If there are any questions that you have about the documentation
+of this library extension that the docs do not currently cover over, please
+feel free to reach out to others on the `Discord`_ server or by starting a
+discussion on GitHub!
 
-    import discord
-    from discord.ext import commands
-    from discord_slash import SlashCommand
-    from discord_slash import SlashContext
-
-    bot = commands.Bot(command_prefix="!", intents=discord.Intents.all())
-    slash = SlashCommand(bot)
-
-
-    @slash.slash(name="test")
-    async def _test(ctx: SlashContext):
-        embed = discord.Embed(title="embed test")
-        await ctx.send(content="test", embeds=[embed])
-
-
-    bot.run("discord_token")
+.. _quickstart: https://discord-py-slash-command.readthedocs.io/en/latest/quickstart.html
+.. _Discord: https://discord.gg/KkgMBVuEkx
 
 .. toctree::
    :maxdepth: 2
    :caption: Contents:
 
    quickstart.rst
-   discord_slash.rst
-   events.rst
-   discord_slash.utils.rst
    faq.rst
-
-
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,9 @@ discussion on GitHub!
    :caption: Contents:
 
    quickstart.rst
+   discord_slash.rst
+   events.rst
+   discord_slash.utils.rst
    faq.rst
 
 Indices and tables


### PR DESCRIPTION
Let's just begin with giving them basic information, and direct them to the quickstart. I'd like to introduce new pages after quickstart that start doing the more "advanced" things as previously mentioned, and will also refer to the packages you've written before.

## Changes

- This adds something new.
- (If required) Document string is updated/added.
- This changes anything except python code. (README, docs, etc.)

## About this pull request

Changes front page of docs.