### PR TITLE
Automatically call get_cog_commands for all cogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ class Slash(commands.Cog):
             # Creates new SlashCommand instance to bot if bot doesn't have.
             bot.slash = SlashCommand(bot, override_type=True)
         self.bot = bot
-        self.bot.slash.get_cog_commands(self)
 
     def cog_unload(self):
         self.bot.slash.remove_cog_commands(self)

--- a/README.md
+++ b/README.md
@@ -71,9 +71,6 @@ class Slash(commands.Cog):
             bot.slash = SlashCommand(bot, override_type=True)
         self.bot = bot
 
-    def cog_unload(self):
-        self.bot.slash.remove_cog_commands(self)
-
     @cog_ext.cog_slash(name="test")
     async def _test(self, ctx: SlashContext):
         embed = discord.Embed(title="embed test")

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -60,9 +60,12 @@ class SlashCommand:
                 self.get_cog_commands(cog)
             self._discord.add_cog = override_add_cog
             default_remove_function = self._discord.remove_cog
-            def override_remove_cog(cog: commands.Cog):
-                default_remove_function(cog)
+            def override_remove_cog(name: str):
+                cog = self._discord.get_cog(name)
+                if cog is None:
+                    return
                 self.remove_cog_commands(cog)
+                default_remove_function(name)
             self._discord.remove_cog = override_remove_cog
 
     def get_cog_commands(self, cog: commands.Cog):

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -62,6 +62,10 @@ class SlashCommand:
         :param cog: Cog that has slash commands.
         :type cog: discord.ext.commands.Cog
         """
+        if hasattr(cog, '_slash_registered'): # Temporary warning
+            return self.logger.warning("Calling get_cog_commands is no longer required "
+            "to add cog slash commands. Make sure to remove all calls to this function.")
+        cog._slash_registered = True # Assuming all went well
         func_list = [getattr(cog, x) for x in dir(cog)]
         res = [x for x in func_list if isinstance(x, (model.CogCommandObject, model.CogSubcommandObject))]
         for x in res:
@@ -139,6 +143,9 @@ class SlashCommand:
         """
         await self._discord.wait_until_ready()  # In case commands are still not registered to SlashCommand.
         self.logger.info("Registering commands...")
+        if isinstance(self._discord, commands.Bot):
+            for cog in self._discord.cogs.values():
+                self.get_cog_commands(cog)
         for x in self.commands:
             selected = self.commands[x]
             if selected.has_subcommands and selected.func:

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -59,6 +59,9 @@ class SlashCommand:
         """
         Gets slash command from :class:`discord.ext.commands.Cog`.
 
+        .. note::
+            This gets called automatically during ``register_all_commands()``.
+
         :param cog: Cog that has slash commands.
         :type cog: discord.ext.commands.Cog
         """

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -54,6 +54,16 @@ class SlashCommand:
         else:
             self._discord.add_listener(self.on_socket_response)
             self.has_listener = True
+            default_add_function = self._discord.add_cog
+            def override_add_cog(cog: commands.Cog):
+                self.get_cog_commands(cog)
+                default_add_function(cog)
+            self._discord.add_cog = override_add_cog
+            default_remove_function = self._discord.remove_cog
+            def override_remove_cog(cog: commands.Cog):
+                self.remove_cog_commands(cog)
+                default_remove_function(cog)
+            self._discord.remove_cog = override_remove_cog
 
     def get_cog_commands(self, cog: commands.Cog):
         """
@@ -148,9 +158,6 @@ class SlashCommand:
         """
         await self._discord.wait_until_ready()  # In case commands are still not registered to SlashCommand.
         self.logger.info("Registering commands...")
-        if isinstance(self._discord, commands.Bot):
-            for cog in self._discord.cogs.values():
-                self.get_cog_commands(cog)
         for x in self.commands:
             selected = self.commands[x]
             if selected.has_subcommands and selected.func:

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -56,13 +56,13 @@ class SlashCommand:
             self.has_listener = True
             default_add_function = self._discord.add_cog
             def override_add_cog(cog: commands.Cog):
-                self.get_cog_commands(cog)
                 default_add_function(cog)
+                self.get_cog_commands(cog)
             self._discord.add_cog = override_add_cog
             default_remove_function = self._discord.remove_cog
             def override_remove_cog(cog: commands.Cog):
-                self.remove_cog_commands(cog)
                 default_remove_function(cog)
+                self.remove_cog_commands(cog)
             self._discord.remove_cog = override_remove_cog
 
     def get_cog_commands(self, cog: commands.Cog):

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -122,7 +122,7 @@ class SlashCommand:
         Removes slash command from :class:`discord.ext.commands.Cog`.
 
         .. note::
-            Since version ``1.0.X``, this gets called automatically during cog deinitialization.
+            Since version ``1.0.9``, this gets called automatically during cog deinitialization.
 
         :param cog: Cog that has slash commands.
         :type cog: discord.ext.commands.Cog

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -73,7 +73,7 @@ class SlashCommand:
         Gets slash command from :class:`discord.ext.commands.Cog`.
 
         .. note::
-            Since version ``1.0.X``, this gets called automatically during cog initialization.
+            Since version ``1.0.9``, this gets called automatically during cog initialization.
 
         :param cog: Cog that has slash commands.
         :type cog: discord.ext.commands.Cog

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -70,7 +70,7 @@ class SlashCommand:
         Gets slash command from :class:`discord.ext.commands.Cog`.
 
         .. note::
-            This gets called automatically during ``register_all_commands()``.
+            Since version ``1.0.X``, this gets called automatically during cog initialization.
 
         :param cog: Cog that has slash commands.
         :type cog: discord.ext.commands.Cog
@@ -117,6 +117,9 @@ class SlashCommand:
     def remove_cog_commands(self, cog):
         """
         Removes slash command from :class:`discord.ext.commands.Cog`.
+
+        .. note::
+            Since version ``1.0.X``, this gets called automatically during cog deinitialization.
 
         :param cog: Cog that has slash commands.
         :type cog: discord.ext.commands.Cog

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -108,6 +108,8 @@ class SlashCommand:
         :param cog: Cog that has slash commands.
         :type cog: discord.ext.commands.Cog
         """
+        if hasattr(cog, '_slash_registered'):
+            del cog._slash_registered
         func_list = [getattr(cog, x) for x in dir(cog)]
         res = [x for x in func_list if
                isinstance(x, (model.CogCommandObject, model.CogSubcommandObject))]

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -25,9 +25,6 @@ def cog_slash(*,
                     bot.slash = SlashCommand(bot, override_type=True)
                 self.bot = bot
 
-            def cog_unload(self):
-                self.bot.slash.remove_cog_commands(self)
-
             @cog_ext.cog_slash(name="ping")
             async def ping(self, ctx: SlashContext):
                 await ctx.send(content="Pong!")
@@ -93,10 +90,6 @@ def cog_subcommand(*,
                     # Creates new SlashCommand instance to bot if bot doesn't have.
                     bot.slash = SlashCommand(bot, override_type=True)
                 self.bot = bot
-                self.bot.slash.get_cog_commands(self)
-
-            def cog_unload(self):
-                self.bot.slash.remove_cog_commands(self)
 
             @cog_ext.cog_subcommand(base="group", name="say")
             async def group_say(self, ctx: SlashContext, text: str):

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -24,7 +24,6 @@ def cog_slash(*,
                     # Creates new SlashCommand instance to bot if bot doesn't have.
                     bot.slash = SlashCommand(bot, override_type=True)
                 self.bot = bot
-                self.bot.slash.get_cog_commands(self)
 
             def cog_unload(self):
                 self.bot.slash.remove_cog_commands(self)


### PR DESCRIPTION
## Changes

- [x] I checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Document string is updated/added.
- [x] This changes anything except python code. (README, docs, etc.)

## About this pull request
This removes the necessity to call ``get_cog_commands()`` on each cog by automatically doing so in ``register_all_commands()``. It also displays a temporary warning that the call is no longer required. README and docs have been updated to reflect this.

Also, first PR hype?