### PR TITLE
Add cmd management to http.py

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -208,35 +208,39 @@ class SlashCommand:
                         options.append(base_dict)
                 if selected.allowed_guild_ids:
                     for y in selected.allowed_guild_ids:
-                        await manage_commands.add_slash_command(self._discord.user.id,
-                                                                self._discord.http.token,
-                                                                y,
-                                                                x,
-                                                                selected.description or "No Description.",
-                                                                options)
+                        await self.req.add_slash_command(
+                            self._discord.user.id,
+                            y,
+                            x,
+                            selected.description or "No Description.",
+                            options,
+                        )
                 else:
-                    await manage_commands.add_slash_command(self._discord.user.id,
-                                                            self._discord.http.token,
-                                                            None,
-                                                            x,
-                                                            selected.description or "No Description.",
-                                                            options)
+                     await self.req.add_slash_command(
+                        self._discord.user.id,
+                        None,
+                        x,
+                        selected.description or "No Description.",
+                        options,
+                    )
                 continue
             if selected.allowed_guild_ids:
                 for y in selected.allowed_guild_ids:
-                    await manage_commands.add_slash_command(self._discord.user.id,
-                                                            self._discord.http.token,
-                                                            y,
-                                                            x,
-                                                            selected.description or "No Description.",
-                                                            selected.options)
+                    await self.req.add_slash_command(
+                        self._discord.user.id,
+                        y,
+                        x,
+                        selected.description or "No Description.",
+                        selected.options,
+                    )
             else:
-                await manage_commands.add_slash_command(self._discord.user.id,
-                                                        self._discord.http.token,
-                                                        None,
-                                                        x,
-                                                        selected.description or "No Description.",
-                                                        selected.options)
+                await self.req.add_slash_command(
+                    self._discord.user.id,
+                    None,
+                    x,
+                    selected.description or "No Description.",
+                    selected.options,
+                )
         self.logger.info("Completed registering all commands!")
 
     async def delete_unused_commands(self):
@@ -248,19 +252,18 @@ class SlashCommand:
         await self._discord.wait_until_ready()
         self.logger.info("Deleting unused commands...")
         registered_commands = {}
-        global_commands = await manage_commands.get_all_commands(self._discord.user.id,
-                                                                 self._discord.http.token,
-                                                                 None)
+        global_commands = await self.req.get_all_commands(self._discord.user.id, None)
+
         for cmd in global_commands:
             registered_commands[cmd["name"]] = {"id": cmd["id"], "guild_id": None}
 
         for guild in self._discord.guilds:
             # Since we can only get commands per guild we need to loop through every one
             try:
-                guild_commands = await manage_commands.get_all_commands(self._discord.user.id,
-                                                                        self._discord.http.token,
-                                                                        guild.id)
-            except error.RequestFailure:
+                guild_commands = await self.req.get_all_commands(
+                    self._discord.user.id, guild.id
+                )
+            except discord.Forbidden:
                 # In case a guild has not granted permissions to access commands
                 continue
 
@@ -271,10 +274,9 @@ class SlashCommand:
             if x not in self.commands:
                 # Delete command if not found locally
                 selected = registered_commands[x]
-                await manage_commands.remove_slash_command(self._discord.user.id,
-                                                           self._discord.http.token,
-                                                           selected["guild_id"],
-                                                           selected["id"])
+                await self.req.remove_slash_command(
+                    self._discord.user.id, selected["guild_id"], selected["id"]
+                )
 
         self.logger.info("Completed deleting unused commands!")
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -209,7 +209,6 @@ class SlashCommand:
                 if selected.allowed_guild_ids:
                     for y in selected.allowed_guild_ids:
                         await self.req.add_slash_command(
-                            self._discord.user.id,
                             y,
                             x,
                             selected.description or "No Description.",
@@ -217,7 +216,6 @@ class SlashCommand:
                         )
                 else:
                      await self.req.add_slash_command(
-                        self._discord.user.id,
                         None,
                         x,
                         selected.description or "No Description.",
@@ -227,7 +225,6 @@ class SlashCommand:
             if selected.allowed_guild_ids:
                 for y in selected.allowed_guild_ids:
                     await self.req.add_slash_command(
-                        self._discord.user.id,
                         y,
                         x,
                         selected.description or "No Description.",
@@ -235,7 +232,6 @@ class SlashCommand:
                     )
             else:
                 await self.req.add_slash_command(
-                    self._discord.user.id,
                     None,
                     x,
                     selected.description or "No Description.",
@@ -252,7 +248,7 @@ class SlashCommand:
         await self._discord.wait_until_ready()
         self.logger.info("Deleting unused commands...")
         registered_commands = {}
-        global_commands = await self.req.get_all_commands(self._discord.user.id, None)
+        global_commands = await self.req.get_all_commands(None)
 
         for cmd in global_commands:
             registered_commands[cmd["name"]] = {"id": cmd["id"], "guild_id": None}
@@ -260,9 +256,7 @@ class SlashCommand:
         for guild in self._discord.guilds:
             # Since we can only get commands per guild we need to loop through every one
             try:
-                guild_commands = await self.req.get_all_commands(
-                    self._discord.user.id, guild.id
-                )
+                guild_commands = await self.req.get_all_commands(guild.id)
             except discord.Forbidden:
                 # In case a guild has not granted permissions to access commands
                 continue
@@ -274,9 +268,7 @@ class SlashCommand:
             if x not in self.commands:
                 # Delete command if not found locally
                 selected = registered_commands[x]
-                await self.req.remove_slash_command(
-                    self._discord.user.id, selected["guild_id"], selected["id"]
-                )
+                await self.req.remove_slash_command(selected["guild_id"], selected["id"])
 
         self.logger.info("Completed deleting unused commands!")
 

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -71,7 +71,7 @@ class SlashContext:
         :param eat: Whether to eat user's input. Default ``False``.
         """
         base = {"type": 2 if eat else 5}
-        _task = self.bot.loop.create_task(self._http.post(base, False, self.bot.user.id, self.interaction_id, self.__token, True))
+        _task = self.bot.loop.create_task(self._http.post(base, False, self.interaction_id, self.__token, True))
         self.sent = True
         if not eat:
             with suppress(asyncio.TimeoutError):
@@ -165,12 +165,11 @@ class SlashContext:
             else self.bot.allowed_mentions.to_dict() if self.bot.allowed_mentions else {}
         }
 
-        resp = await self._http.post(base, wait, self.bot.user.id, self.interaction_id, self.__token, files=files)
+        resp = await self._http.post(base, wait, self.interaction_id, self.__token, files=files)
         smsg = model.SlashMessage(state=self.bot._connection,
                                   data=resp,
                                   channel=self.channel if isinstance(self.channel, discord.TextChannel) else discord.Object(id=self.channel),
                                   _http=self._http,
-                                  bot_id=self.bot.user.id,
                                   interaction_token=self.__token)
         if delete_after:
             self.bot.loop.create_task(smsg.delete(delay=delete_after))
@@ -184,11 +183,11 @@ class SlashContext:
             "allowed_mentions": allowed_mentions.to_dict() if allowed_mentions
             else self.bot.allowed_mentions.to_dict() if self.bot.allowed_mentions else {}
         }
-        return self._http.post(base, False, self.bot.user.id, self.interaction_id, self.__token)
+        return self._http.post(base, False, self.interaction_id, self.__token)
 
     def send_hidden(self, content: str = ""):
         base = {
             "content": content,
             "flags": 64
         }
-        return self._http.post(base, False, self.bot.user.id, self.interaction_id, self.__token)
+        return self._http.post(base, False, self.interaction_id, self.__token)

--- a/discord_slash/http.py
+++ b/discord_slash/http.py
@@ -68,9 +68,6 @@ class SlashCommandRequest:
         url += "/commands" if not guild_id else f"/guilds/{guild_id}/commands"
         url += url_ending
         route = CustomRoute(method, url)
-        self.logger.info(method)
-        self.logger.info(url)
-        self.logger.info(kwargs)
         return self._discord.http.request(route, **kwargs)
 
     def post(self, _resp, wait: bool, bot_id, interaction_id, token, initial=False, files: typing.List[discord.File] = None):

--- a/discord_slash/http.py
+++ b/discord_slash/http.py
@@ -15,36 +15,33 @@ class SlashCommandRequest:
         self.logger = logger
         self._discord: typing.Union[discord.Client, discord.AutoShardedClient] = _discord
 
-    def remove_slash_command(self, bot_id, guild_id, cmd_id):
+    def remove_slash_command(self, guild_id, cmd_id):
         """
         Sends a slash command delete request to Discord API.
 
-        :param bot_id: User ID of the bot.
         :param guild_id: ID of the guild to add command. Pass `None` to add global command.
         :param cmd_id: ID of the command.
         :return: Response code of the request.
         """
         return self.command_request(
-            method="DELETE", bot_id=bot_id, guild_id=guild_id, url_ending=f"/{cmd_id}"
+            method="DELETE", guild_id=guild_id, url_ending=f"/{cmd_id}"
         )
 
-    def get_all_commands(self, bot_id, guild_id=None):
+    def get_all_commands(self, guild_id=None):
         """
         Sends a slash command get request to Discord API for all commands.
 
-        :param bot_id: User ID of the bot.
         :param guild_id: ID of the guild to add command. Pass `None` to add global command.
         :return: JSON Response of the request.
         """
-        return self.command_request(method="GET", bot_id=bot_id, guild_id=guild_id)
+        return self.command_request(method="GET", guild_id=guild_id)
 
     def add_slash_command(
-        self, bot_id, guild_id, cmd_name: str, description: str, options: list = None
+        self, guild_id, cmd_name: str, description: str, options: list = None
     ):
         """
         Sends a slash command add request to Discord API.
 
-        :param bot_id: User ID of the bot.
         :param guild_id: ID of the guild to add command. Pass `None` to add global command.
         :param cmd_name: Name of the command. Must be 3 or longer and 32 or shorter.
         :param description: Description of the command.
@@ -52,25 +49,24 @@ class SlashCommandRequest:
         :return: JSON Response of the request.
         """
         base = {"name": cmd_name, "description": description, "options": options or []}
-        return self.command_request(json=base, method="POST", bot_id = bot_id, guild_id = guild_id)
+        return self.command_request(json=base, method="POST", guild_id = guild_id)
 
-    def command_request(self, method, bot_id, guild_id, url_ending="", **kwargs):
+    def command_request(self, method, guild_id, url_ending="", **kwargs):
         r"""
         Sends a command request to discord (post, get, delete, etc)
 
         :param method: HTTP method.
-        :param bot_id: User ID of the bot.
         :param guild_id: ID of the guild to make the request on. `None` to make a request on the global scope.
         :param url_ending: String to append onto the end of the url.
         :param \**kwargs: Kwargs to pass into discord.py's `request function <https://github.com/Rapptz/discord.py/blob/master/discord/http.py#L134>`_
         """
-        url = f"/applications/{bot_id}"
+        url = f"/applications/{self._discord.user.id}"
         url += "/commands" if not guild_id else f"/guilds/{guild_id}/commands"
         url += url_ending
         route = CustomRoute(method, url)
         return self._discord.http.request(route, **kwargs)
 
-    def post(self, _resp, wait: bool, bot_id, interaction_id, token, initial=False, files: typing.List[discord.File] = None):
+    def post(self, _resp, wait: bool, interaction_id, token, initial=False, files: typing.List[discord.File] = None):
         """
         Sends command response POST request to Discord API.
 
@@ -78,7 +74,6 @@ class SlashCommandRequest:
         :type _resp: dict
         :param wait: Whether the server should wait before sending a response.
         :type wait: bool
-        :param bot_id: Bot ID.
         :param interaction_id: Interaction ID.
         :param token: Command message token.
         :param initial: Whether this request is initial. Default ``False``
@@ -87,13 +82,13 @@ class SlashCommandRequest:
         :return: Coroutine
         """
         if files:
-            return self.post_with_files(_resp, wait, files, bot_id, token)
-        req_url = f"/interactions/{interaction_id}/{token}/callback" if initial else f"/webhooks/{bot_id}/{token}?wait={'true' if wait else 'false'}"
+            return self.post_with_files(_resp, wait, files, token)
+        req_url = f"/interactions/{interaction_id}/{token}/callback" if initial else f"/webhooks/{self._discord.user.id}/{token}?wait={'true' if wait else 'false'}"
         route = CustomRoute("POST", req_url)
         return self._discord.http.request(route, json=_resp)
 
-    def post_with_files(self, _resp, wait: bool, files: typing.List[discord.File], bot_id, token):
-        req_url = f"/webhooks/{bot_id}/{token}?wait={'true' if wait else 'false'}"
+    def post_with_files(self, _resp, wait: bool, files: typing.List[discord.File], token):
+        req_url = f"/webhooks/{self._discord.user.id}/{token}?wait={'true' if wait else 'false'}"
         route = CustomRoute("POST", req_url)
         form = aiohttp.FormData()
         form.add_field("payload_json", json.dumps(_resp))
@@ -103,30 +98,28 @@ class SlashCommandRequest:
             form.add_field(name, sel.fp, filename=sel.filename, content_type="application/octet-stream")
         return self._discord.http.request(route, data=form, files=files)
 
-    def edit(self, _resp, bot_id, token, message_id="@original"):
+    def edit(self, _resp, token, message_id="@original"):
         """
         Sends edit command response POST request to Discord API.
 
         :param _resp: Edited response.
         :type _resp: dict
-        :param bot_id: Bot ID.
         :param token: Command message token.
         :param message_id: Message ID to edit. Default initial message.
         :return: Coroutine
         """
-        req_url = f"/webhooks/{bot_id}/{token}/messages/{message_id}"
+        req_url = f"/webhooks/{self._discord.user.id}/{token}/messages/{message_id}"
         route = CustomRoute("PATCH", req_url)
         return self._discord.http.request(route, json=_resp)
 
-    def delete(self, bot_id, token, message_id="@original"):
+    def delete(self, token, message_id="@original"):
         """
         Sends delete command response POST request to Discord API.
 
-        :param bot_id: Bot ID.
         :param token: Command message token.
         :param message_id: Message ID to delete. Default initial message.
         :return: Coroutine
         """
-        req_url = f"/webhooks/{bot_id}/{token}/messages/{message_id}"
+        req_url = f"/webhooks/{self._discord.user.id}/{token}/messages/{message_id}"
         route = CustomRoute("DELETE", req_url)
         return self._discord.http.request(route)

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -151,11 +151,10 @@ class SlashCommandOptionType(IntEnum):
 
 class SlashMessage(discord.Message):
     """discord.py's :class:`discord.Message` but overridden ``edit`` and ``delete`` to work for slash command."""
-    def __init__(self, *, state, channel, data, _http: http.SlashCommandRequest, bot_id, interaction_token):
+    def __init__(self, *, state, channel, data, _http: http.SlashCommandRequest, interaction_token):
         # Yes I know it isn't the best way but this makes implementation simple.
         super().__init__(state=state, channel=channel, data=data)
         self._http = _http
-        self.bot_id = bot_id
         self.__interaction_token = interaction_token
 
     async def edit(self, **fields):
@@ -186,7 +185,7 @@ class SlashMessage(discord.Message):
             _resp["allowed_mentions"] = allowed_mentions.to_dict() if allowed_mentions else \
                 self._state.allowed_mentions.to_dict() if self._state.allowed_mentions else {}
 
-            await self._http.edit(_resp, self.bot_id, self.__interaction_token, self.id)
+            await self._http.edit(_resp, self.__interaction_token, self.id)
 
             delete_after = fields.get("delete_after")
             if delete_after:
@@ -198,10 +197,10 @@ class SlashMessage(discord.Message):
             await super().delete(delay=delay)
         except discord.Forbidden:
             if not delay:
-                return await self._http.delete(self.bot_id, self.__interaction_token, self.id)
+                return await self._http.delete(self.__interaction_token, self.id)
 
             async def wrap():
                 with suppress(discord.HTTPException):
                     await asyncio.sleep(delay)
-                    await self._http.delete(self.bot_id, self.__interaction_token, self.id)
+                    await self._http.delete(self.__interaction_token, self.id)
             self._state.loop.create_task(wrap())


### PR DESCRIPTION
## About this pull request
This is needed because previously `utils.manage_commands` functions were used in `auto_register` and `auto_delete` and those functions created an aiohttp session for each function, which to quote aiohttp's docs "making a session for every request is a **very bad** idea."
This creates functions in `http.SlashCommandRequest` that use discord's session to make requests.

## Changes
Adds `add_slash_command`, `remove_slash_command`, `get_all_commands` and `command_request` to `SlashCommandRequest`
Changes `register_all_commands` and `delete_unused_commands` to use the new functions.
- [x] I checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Document string is updated/added.
- [ ] This changes anything except python code. (README, docs, etc.)