### PR TITLE
Implement PUT requests in auto_register

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -174,9 +174,10 @@ class SlashCommand:
                 # so we will warn this at registering subcommands.
                 self.logger.warning(f"Detected command name with same subcommand base name! "
                                     f"This command will only have subcommand: {x}")
+            
+            options = []
             if selected.has_subcommands:
                 tgt = self.subcommands[x]
-                options = []
                 for y in tgt:
                     sub = tgt[y]
                     if isinstance(sub, model.SubcommandObject):
@@ -206,36 +207,21 @@ class SlashCommand:
                             if sub_sub.subcommand_group_description:
                                 base_dict["description"] = sub_sub.subcommand_group_description
                         options.append(base_dict)
-                if selected.allowed_guild_ids:
-                    for y in selected.allowed_guild_ids:
-                        await self.req.add_slash_command(
-                            y,
-                            x,
-                            selected.description or "No Description.",
-                            options,
-                        )
-                else:
-                     await self.req.add_slash_command(
-                        None,
-                        x,
-                        selected.description or "No Description.",
-                        options,
-                    )
-                continue
+                        
             if selected.allowed_guild_ids:
                 for y in selected.allowed_guild_ids:
                     await self.req.add_slash_command(
                         y,
                         x,
                         selected.description or "No Description.",
-                        selected.options,
+                        selected.options if not options else options,
                     )
             else:
                 await self.req.add_slash_command(
                     None,
                     x,
                     selected.description or "No Description.",
-                    selected.options,
+                    selected.options if not options else options,
                 )
         self.logger.info("Completed registering all commands!")
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -254,15 +254,14 @@ class SlashCommand:
         commands = await self.to_dict()
         self.logger.info("Syncing commands...")
         all_bot_guilds = [guild.id for guild in self._discord.guilds]
-        print(all_bot_guilds)
         # This is an extremly bad way to do this, because slash cmds can be in guilds the bot isn't in
-        # But it's the only way until discord make an endpoint to request all the guild with cmds registered.
+        # But it's the only way until discord makes an endpoint to request all the guild with cmds registered.
+
         await self.req.put_slash_commands(slash_commands = commands["global"], guild_id = None)
         
         for guild in commands["guild"]:
             await self.req.put_slash_commands(slash_commands = commands["guild"][guild], guild_id = guild)
             all_bot_guilds.remove(guild)
-        print(all_bot_guilds)
         if delete_from_unused_guilds:
             for guild in all_bot_guilds:
                 await self.req.put_slash_commands(slash_commands=[], guild_id = guild)

--- a/discord_slash/http.py
+++ b/discord_slash/http.py
@@ -15,6 +15,18 @@ class SlashCommandRequest:
         self.logger = logger
         self._discord: typing.Union[discord.Client, discord.AutoShardedClient] = _discord
 
+    def put_slash_commands(self, slash_commands: list, guild_id):
+        """
+        Sends a slash command put request to the Discord API
+
+        ``slash_commands`` must contain all the commands
+        :param slash_commands: List of all the slash commands to make a put request to discord with.
+        :param guild_id: ID of the guild to set the commands on. Pass `None` for the global scope.
+        """
+        return self.command_request(
+            method="PUT", guild_id = guild_id, json = slash_commands
+        )
+
     def remove_slash_command(self, guild_id, cmd_id):
         """
         Sends a slash command delete request to Discord API.


### PR DESCRIPTION
## About this pull request

This implements PUT requests for registering commands when `auto_register` and `auto_delete` are both true.
This will reduce the amount of requests made to discord, only one per guild/global compared to one request for each command for each scope.

## Changes 

- Added a `to_dict` to `SlashCommand` function to get all commands into a dictionary, this reduces duplicated code from `register_all_commands` and `sync_all_commands`
- Added `sync_all_commands` to `SlashCommand` which uses PUT requests to update the commands.
- Automatically call `sync_all_commands` when both `auto_register` and `auto_delete` are `True`
- Only call `register_all_commands` when `auto_register` is `True` and `auto_delete` isn't.
- Only call `delete_unused_commands` when `auto_register` is `True` and `auto_delete` isn't.
- Add `put_slash_commands` to http

## Checklist

- [x] I checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Document string is updated/added.
- [ ] This changes anything except python code. (README, docs, etc.)

