### PR TITLE
Fix duplicated slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,15 +61,23 @@ bot.run("discord_token")
 ### Advanced
 This offers implementation of the slash command library in the usage of a cog.
 ```py
+# bot.py
+from discord.ext import commands
+from discord_slash import SlashCommand
+
+bot = commands.Bot(command_prefix="prefix")
+slash = SlashCommand(bot, override_type = True)
+
+bot.load_extension("cog")
+bot.run("TOKEN")
+
+# cog.py
 import discord
 from discord.ext import commands
-from discord_slash import cog_ext, SlashCommand, SlashContext
+from discord_slash import cog_ext, SlashContext
 
 class Slash(commands.Cog):
     def __init__(self, bot):
-        if not hasattr(bot, "slash"):
-            # Creates new SlashCommand instance to bot if bot doesn't have.
-            bot.slash = SlashCommand(bot, override_type=True)
         self.bot = bot
 
     @cog_ext.cog_slash(name="test")

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -52,6 +52,11 @@ class SlashCommand:
             self._discord.on_socket_response = self.on_socket_response
             self.has_listener = False
         else:
+            if not hasattr(self._discord, 'slash'):
+                self._discord.slash = self
+            else:
+                raise error.DuplicateSlashClient("You can't have duplicate SlashCommand instances!")
+            
             self._discord.add_listener(self.on_socket_response)
             self.has_listener = True
             default_add_function = self._discord.add_cog
@@ -67,6 +72,8 @@ class SlashCommand:
                 self.remove_cog_commands(cog)
                 default_remove_function(name)
             self._discord.remove_cog = override_remove_cog
+        
+        
 
     def get_cog_commands(self, cog: commands.Cog):
         """

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -20,9 +20,6 @@ def cog_slash(*,
 
         class ExampleCog(commands.Cog):
             def __init__(self, bot):
-                if not hasattr(bot, "slash"):
-                    # Creates new SlashCommand instance to bot if bot doesn't have.
-                    bot.slash = SlashCommand(bot, override_type=True)
                 self.bot = bot
 
             @cog_ext.cog_slash(name="ping")
@@ -86,9 +83,6 @@ def cog_subcommand(*,
 
         class ExampleCog(commands.Cog):
             def __init__(self, bot):
-                if not hasattr(bot, "slash"):
-                    # Creates new SlashCommand instance to bot if bot doesn't have.
-                    bot.slash = SlashCommand(bot, override_type=True)
                 self.bot = bot
 
             @cog_ext.cog_subcommand(base="group", name="say")

--- a/discord_slash/error.py
+++ b/discord_slash/error.py
@@ -1,3 +1,9 @@
+class DuplicateSlashClient(Exception):
+    """
+    There are duplicate :class:`client.SlashCommand` instances.
+    """
+
+
 class SlashCommandError(Exception):
     """
     All exceptions of this extension can be captured with this.

--- a/discord_slash/error.py
+++ b/discord_slash/error.py
@@ -1,6 +1,6 @@
 class DuplicateSlashClient(Exception):
     """
-    There are duplicate :class:`client.SlashCommand` instances.
+    There are duplicate :class:`.SlashCommand` instances.
     """
 
 


### PR DESCRIPTION
## About this pr

When there are multiple `SlashCommand` instances, auto_delete conflicts.
Both instances try to make the commands on discord match the commands, so some commands get deleted, etc
This is likely to happen with a `slash = ` in a bot file, and `bot.slash = ` in a cog (or more)
This pr also coincidentally fixes the issue of potentially having different settings, depending on the order cogs are loaded.

## Changes

Add `self` to `bot.slash` on init of `SlashCommand`, if it already exists raise an error.

- [x] I checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [x] There is/are breaking change(s).
- [x] (If required) Document string is updated/added.
- [ ] This changes anything except python code. (README, docs, etc.)