### PR TITLE
Resolves #84 - Pass type to create_option

### DIFF
--- a/discord_slash/error.py
+++ b/discord_slash/error.py
@@ -48,3 +48,8 @@ class CheckFailure(SlashCommandError):
     """
     Command check has failed.
     """
+
+class IncorrectType(SlashCommandError):
+    """
+    Type passed was incorrect
+    """

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -176,8 +176,9 @@ class SlashCommandOptionType(IntEnum):
         :return: :class:`.model.SlashCommandOptionType` or ``None``
         """
         if issubclass(t, str): return cls.STRING
-        if issubclass(t, int): return cls.INTEGER
         if issubclass(t, bool): return cls.BOOLEAN
+        # The check for bool MUST be above the check for integers as booleans subclass integers
+        if issubclass(t, int): return cls.INTEGER
         if issubclass(t, discord.abc.User): return cls.USER
         if issubclass(t, discord.abc.GuildChannel): return cls.CHANNEL
         if issubclass(t, discord.abc.Role): return cls.ROLE

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -161,7 +161,7 @@ def create_option(name: str,
         original_type = option_type
         option_type = SlashCommandOptionType.from_type(original_type)
         if option_type is None:
-            raise IncorrectType(f"The type {original_type} is not reconsied as a type that Discord accepts for slash commands.")
+            raise IncorrectType(f"The type {original_type} is not recognized as a type that Discord accepts for slash commands.")
     return {
         "name": name,
         "description": description,

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -2,7 +2,7 @@ import typing
 import inspect
 import asyncio
 import aiohttp
-from ..error import RequestFailure
+from ..error import RequestFailure, IncorrectType
 from ..model import SlashCommandOptionType
 from collections.abc import Callable
 
@@ -144,7 +144,7 @@ async def remove_all_commands_in(bot_id,
 
 def create_option(name: str,
                   description: str,
-                  option_type: int,
+                  option_type: typing.Union[int, type],
                   required: bool,
                   choices: list = None) -> dict:
     """
@@ -157,6 +157,11 @@ def create_option(name: str,
     :param choices: Choices of the option. Can be empty.
     :return: dict
     """
+    if not isinstance(option_type, int) or isinstance(option_type, bool): #Bool values are a subclass of int
+        original_type = option_type
+        option_type = SlashCommandOptionType.from_type(original_type)
+        if option_type is None:
+            raise IncorrectType(f"The type {original_type} is not reconsied as a type that Discord accepts for slash commands.")
     return {
         "name": name,
         "description": description,


### PR DESCRIPTION
## About this pull request

Adds a call to `SlashCommandOptionType.from_type` if the type passed was not an int

## Changes

- Restructure `SlashCommandOptionType.from_type` because currently if `bool` is passed it will return the value for an integer (this is because bool is a subclass of integer)
- Adds a call to `SlashCommandOptionType.from_type` if the type passed was not an int
- Adds an error `IncorrectType` which is raised if `from_type` doesn't return anything

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #84 
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
