### PR TITLE
Allow command for all used guilds in subcommands

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -425,8 +425,8 @@ class SlashCommand:
         name = name.lower()
         description = description or getdoc(cmd)
 
-        if name in self.commands:
-            tgt = self.commands[name]
+        if base in self.commands:
+            tgt = self.commands[base]
             for x in tgt.allowed_guild_ids:
                 if x not in guild_ids:
                     guild_ids.append(x)


### PR DESCRIPTION
## About this pull request

This issue won't `fix` #88 but it will make the command to be visible for all guilds used in subcommands.

## Changes

* Fix base commands lookup for the subcommand.

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: 
- [ ] This adds something new.
- [x] There is/are breaking change(s).
- [ ] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
