### PR TITLE
Makes temporary_auto_convert Case Insensitive 

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -649,6 +649,7 @@ class SlashCommand:
 
             # This is to temporarily fix Issue #97, that on Android device
             # does not give option type from API.
+            print(temporary_auto_convert)
             if "type" not in x:
                 x["type"] = temporary_auto_convert[x["name"]]
 
@@ -738,7 +739,7 @@ class SlashCommand:
             # does not give option type from API.
             temporary_auto_convert = {}
             for x in selected_cmd.options:
-                temporary_auto_convert[x["name"]] = x["type"]
+                temporary_auto_convert[x["name"].lower()] = x["type"]
 
             args = await self.process_options(ctx.guild, to_use["data"]["options"], selected_cmd.connector, temporary_auto_convert) \
                 if "options" in to_use["data"] else {}

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -649,7 +649,6 @@ class SlashCommand:
 
             # This is to temporarily fix Issue #97, that on Android device
             # does not give option type from API.
-            print(temporary_auto_convert)
             if "type" not in x:
                 x["type"] = temporary_auto_convert[x["name"]]
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -649,6 +649,7 @@ class SlashCommand:
 
             # This is to temporarily fix Issue #97, that on Android device
             # does not give option type from API.
+            print(temporary_auto_convert)
             if "type" not in x:
                 x["type"] = temporary_auto_convert[x["name"]]
 
@@ -778,7 +779,7 @@ class SlashCommand:
                 # does not give option type from API.
                 temporary_auto_convert = {}
                 for n in selected.options:
-                    temporary_auto_convert[n["name"]] = n["type"]
+                    temporary_auto_convert[n["name"].lower()] = n["type"]
 
                 args = await self.process_options(ctx.guild, x["options"], selected.connector, temporary_auto_convert) \
                     if "options" in x else {}
@@ -791,7 +792,7 @@ class SlashCommand:
         # does not give option type from API.
         temporary_auto_convert = {}
         for n in selected.options:
-            temporary_auto_convert[n["name"]] = n["type"]
+            temporary_auto_convert[n["name"].lower()] = n["type"]
 
         args = await self.process_options(ctx.guild, sub_opts, selected.connector, temporary_auto_convert) \
             if "options" in sub else {}


### PR DESCRIPTION
## About this pull request

As the title above, case insensitivity for the temporary fix. Discussed briefly on discord 

## Changes

``lower()`` was added where the arg name was being processed

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This adds something new.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] There is/are breaking change(s).
- [ ] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
