### PR TITLE
Clarify docs, allow a list of strings for choices

### DIFF
--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -156,12 +156,16 @@ def create_option(name: str,
     :param required: Whether this option is required.
     :param choices: Choices of the option. Can be empty.
     :return: dict
+
+    ``choices`` must either be a list of `option type dicts <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice>`_
+    or a list of single string values. 
     """
     if not isinstance(option_type, int) or isinstance(option_type, bool): #Bool values are a subclass of int
         original_type = option_type
         option_type = SlashCommandOptionType.from_type(original_type)
         if option_type is None:
             raise IncorrectType(f"The type {original_type} is not recognized as a type that Discord accepts for slash commands.")
+    choices = [choice if isinstance(choice, dict) else {"name": choice, "value": choice} for choice in choices]
     return {
         "name": name,
         "description": description,

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -157,8 +157,9 @@ def create_option(name: str,
     :param choices: Choices of the option. Can be empty.
     :return: dict
 
-    ``choices`` must either be a list of `option type dicts <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice>`_
-    or a list of single string values. 
+    .. note::
+        ``choices`` must either be a list of `option type dicts <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptionchoice>`_
+        or a list of single string values. 
     """
     if not isinstance(option_type, int) or isinstance(option_type, bool): #Bool values are a subclass of int
         original_type = option_type


### PR DESCRIPTION
## About this pull request

This pr improves the readabilty of the docs in that section, and allows for easier understanding / usage

## Changes

Adds a description of what `choices` should be in `manage_commands.create_option`
Accept single strings in a list as choices, instead of a dict

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
