### PR TITLE
Fix broken link in quickstart

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -2,7 +2,7 @@ Quickstart
 ==========
 
 Before doing anything, it is highly recommended to read discord.py's quickstart.
-You can find it by clicking :ref:`this <discord:quickstart>`.
+You can find it by clicking `here <https://discordpy.readthedocs.io/en/latest/quickstart.html>`_.
 
 Firstly, we will begin by installing the python library extension for discord.py:
 


### PR DESCRIPTION
## About this pull request

The link in quickstart is broken, and does not point to discord py readme

## Changes

Link now points here: https://discordpy.readthedocs.io/en/latest/quickstart.html

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relavent documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
