### PR TITLE
Define subcommand_name

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -764,7 +764,8 @@ class SlashCommand:
         sub_name = sub["name"]
         if sub_name not in base:
             return
-        ctx.subcommand = sub_name
+        if sub_name is not None:
+            ctx.subcommand_name = sub_name        
         sub_opts = sub["options"] if "options" in sub else []
         for x in sub_opts:
             if "options" in x or "value" not in x:

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -765,7 +765,7 @@ class SlashCommand:
         if sub_name not in base:
             return
         if sub_name is not None:
-            ctx.subcommand_name = sub_name        
+            ctx.subcommand_name = sub_name
         sub_opts = sub["options"] if "options" in sub else []
         for x in sub_opts:
             if "options" in x or "value" not in x:

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -764,8 +764,7 @@ class SlashCommand:
         sub_name = sub["name"]
         if sub_name not in base:
             return
-        if sub_name is not None:
-            ctx.subcommand_name = sub_name
+        ctx.subcommand_name = sub_name
         sub_opts = sub["options"] if "options" in sub else []
         for x in sub_opts:
             if "options" in x or "value" not in x:


### PR DESCRIPTION
## About this pull request

``ctx.subcommand_name`` is defined in Context, but is never set, instead ``ctx.subcommand`` is set, but this is not present in the base class of Context. This correctly defines ``ctx.subcommand_name``

## Changes

``ctx.subcommand`` is removed, ``ctx.subcommand_name`` is set

This will break any code that is referencing ``ctx.subcommand``, which should not exist regardless 

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [x] There is/are breaking change(s).
- [ ] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
