### PR TITLE
Fixes and optimisations mainly for guilds with only the applications.commands scope

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -722,11 +722,8 @@ class SlashCommand:
 
             selected_cmd = self.commands[to_use["data"]["name"]]
 
-            if selected_cmd.allowed_guild_ids:
-                guild_id = ctx.guild.id if isinstance(ctx.guild, discord.Guild) else ctx.guild
-
-                if guild_id not in selected_cmd.allowed_guild_ids:
-                    return
+            if selected_cmd.allowed_guild_ids and ctx.guild_id not in selected_cmd.allowed_guild_ids:
+                return
 
             if selected_cmd.has_subcommands and not selected_cmd.func:
                 return await self.handle_subcommand(ctx, to_use)

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -91,7 +91,7 @@ class SlashContext:
         base = {"type": 2 if eat else 5}
         _task = self.bot.loop.create_task(self._http.post(base, self.interaction_id, self.__token, True))
         self.sent = True
-        if not eat:
+        if not eat and (not self.guild_id or (self.channel and self.channel.permissions_for(self.guild.me).view_channel)):
             with suppress(asyncio.TimeoutError):
                 def check(message: discord.Message):
                     user_id = self.author_id

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -184,7 +184,7 @@ class SlashContext:
         resp = await self._http.post(base, self.interaction_id, self.__token, files=files)
         smsg = model.SlashMessage(state=self.bot._connection,
                                   data=resp,
-                                  channel=self.channel or discord.Object(id=self.channel),
+                                  channel=self.channel or discord.Object(id=self.channel_id),
                                   _http=self._http,
                                   interaction_token=self.__token)
         if delete_after:


### PR DESCRIPTION
## About this pull request

This PR fixes some bugs introduced in v1.0.9 for guilds where the bot is not a member (i.e. bot scope) but has been added under the applications.commands scope. It also includes an optimisation that applies to these guilds along with guilds where the bot is a member but cannot view messages in the channel where a command was executed.

## Changes

Each commit in the PR includes an in-depth description of the change.
- 36ce1f6: Fix SlashMessage creation to use SlashContext.guild_id instead of SlashContext.guild as id when generating a discord generic object for the channel.
- 9cb4bb3: Fix issue in client where SlashContext.guild is used instead of SlashContext.guild_id to check whether a command is available for a guild.
- 7812a1d: Avoid waiting to set SlashContext.message in cases where the bot will always time out because it cannot read messages.

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
