### PR TITLE
Update FAQ to remove references to legacy code

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -27,7 +27,7 @@ If you want your commands automatically registered, set ``sync_commands`` to ``T
 
    from discord_slash import SlashCommand
    
-   slash = SlashCommand(client, auto_register=True)
+   slash = SlashCommand(client, sync_commands=True)
 
 Or, if you prefer to have more control, you can use :mod:`.utils.manage_commands`.
 
@@ -44,17 +44,9 @@ For normal slash command, use :meth:`.client.SlashCommand.slash`, and for subcom
 How to delete slash commands?
 *****************************
 
-You can enable auto deletion of unused commands by setting ``auto_delete`` to ``True`` at :class:`.client.SlashCommand`.
+If ``sync_commands`` is set to ``True``, commands will automatically be removed as needed.
 
-.. code-block:: python
-   
-   from discord_slash import SlashCommand
-   slash = SlashCommand(auto_delete = True)
-
-.. note::
-   This will make a request for **every** single guild your bot is in.
-
-Or you can do it manually by this methods:
+However, if you are not using ``sync_commands`` you can do it manually by this methods:
 
 * Deleting a single command with :meth:`utils.manage_commands.remove_slash_command`
 * Deleting all commands using :meth:`utils.manage_commands.remove_all_commands`


### PR DESCRIPTION
## About this pull request

``auto-register`` and ``auto-delete`` were removed. This PR updates the FAQ to reflect this

## Changes

Updated ``Add a slash command on Discord``'s example to use ``sync_commands`` not ``auto_register``

Updated ``How to delete slash commands?`` to remove references to ``auto_delete``

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relavent documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
