### PR TITLE
Change context and http to reflect upcoming changes

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -27,7 +27,7 @@ class SlashContext:
     :ivar _logger: Logger instance.
     :ivar deffered: Whether the command is current deffered (loading state)
     :ivar _deffered_hidden: Internal var to check that state stays the same
-    :ivar sent: Whether you sent the initial response.
+    :ivar responded: Whether you have responded with a message to the interaction.
     :ivar guild_id: Guild ID of the command message. If the command was invoked in DM, then it is ``None``
     :ivar author_id: User ID representing author of the command message.
     :ivar channel_id: Channel ID representing channel of the command message.
@@ -50,7 +50,7 @@ class SlashContext:
         self.bot = _discord
         self._logger = logger
         self.deffered = False
-        self.sent = False
+        self.responded = False
         self._deffered_hidden = False  # To check if the patch to the deffered response matches
         self.guild_id = int(_json["guild_id"]) if "guild_id" in _json.keys() else None
         self.author_id = int(_json["member"]["user"]["id"] if "member" in _json.keys() else _json["user"]["id"])
@@ -86,7 +86,7 @@ class SlashContext:
 
         :param hidden: Whether the deffered response should be ephemeral . Default ``False``.
         """
-        if self.deffered or self.sent:
+        if self.deffered or self.responded:
             raise error.AlreadyResponded("You have already responded to this command!")
         base = {"type": 5}
         if hidden:
@@ -165,7 +165,7 @@ class SlashContext:
             base["flags"] = 64
         
         initial_message = False
-        if not self.sent:
+        if not self.responded:
             initial_message = True
             if files:
                 raise error.IncorrectFormat("You cannot send files in the initial response!")
@@ -187,7 +187,7 @@ class SlashContext:
                     resp = await self._http.edit({}, self.__token)
                 else:
                     resp = {}
-            self.sent = True
+            self.responded = True
         else:
             resp = await self._http.post_followup(base, self.__token, files=files)
         if not hidden:

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -182,7 +182,8 @@ class SlashContext:
                     "type": 4,
                     "data": base
                 }
-                resp = await self._http.post_initial_response(json_data, self._interaction_id, self.__token)
+                await self._http.post_initial_response(json_data, self._interaction_id, self.__token)
+                resp = await self._http.edit({}, self.__token)
             self._sent = True
         else:
             resp = await self._http.post_followup(base, self.__token, files=files)

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -86,6 +86,8 @@ class SlashContext:
 
         :param hidden: Whether the deffered response should be ephemeral . Default ``False``.
         """
+        if self._deffered or self._sent:
+            raise error.AlreadyResponded("You have already responded to this command!")
         base = {"type": 5}
         if hidden:
             base["data"] = {"flags": 64}

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -178,8 +178,11 @@ class SlashContext:
                 resp = await self._http.edit(base, self.__token)
                 self._deffered = False
             else:
-                base["type"] = 4
-                resp = await self._http.post_initial_response(base, self._interaction_id, self.__token)
+                json_data = {
+                    "type": 4,
+                    "data": base
+                }
+                resp = await self._http.post_initial_response(json_data, self._interaction_id, self.__token)
             self._sent = True
         else:
             resp = await self._http.post_followup(base, self.__token, files=files)

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -20,12 +20,14 @@ class SlashContext:
     :ivar name: Name of the command.
     :ivar subcommand_name: Subcommand of the command.
     :ivar subcommand_group: Subcommand group of the command.
-    :ivar interaction_id: Interaction ID of the command message.
+    :ivar _interaction_id: Interaction ID of the command message.
     :ivar command_id: ID of the command.
     :ivar _http: :class:`.http.SlashCommandRequest` of the client.
     :ivar bot: discord.py client.
-    :ivar logger: Logger instance.
-    :ivar sent: Whether you sent the initial response.
+    :ivar _logger: Logger instance.
+    :ivar _deffered: Whether the command is current deffered (loading state)
+    :ivar _deffered_hidden: Internal var to check that state stays the same
+    :ivar _sent: Whether you sent the initial response.
     :ivar guild_id: Guild ID of the command message. If the command was invoked in DM, then it is ``None``
     :ivar author_id: User ID representing author of the command message.
     :ivar channel_id: Channel ID representing channel of the command message.
@@ -42,12 +44,14 @@ class SlashContext:
         self.name = self.command = self.invoked_with = _json["data"]["name"]
         self.subcommand_name = self.invoked_subcommand = self.subcommand_passed = None
         self.subcommand_group = self.invoked_subcommand_group = self.subcommand_group_passed = None
-        self.interaction_id = _json["id"]
+        self._interaction_id = _json["id"]
         self.command_id = _json["data"]["id"]
         self._http = _http
         self.bot = _discord
-        self.logger = logger
-        self.sent = False
+        self._logger = logger
+        self._deffered = False
+        self._sent = False
+        self._deffered_hidden = False  # To check if the patch to the deffered response matches
         self.guild_id = int(_json["guild_id"]) if "guild_id" in _json.keys() else None
         self.author_id = int(_json["member"]["user"]["id"] if "member" in _json.keys() else _json["user"]["id"])
         self.channel_id = int(_json["channel_id"])
@@ -76,39 +80,18 @@ class SlashContext:
         """
         return self.bot.get_channel(self.channel_id)
 
-    async def respond(self, eat: bool = False):
+    async def defer(self, hidden: bool = False):
         """
-        Sends command invoke response.\n
-        You should call this first.
+        'Deferes' the response, showing a loading state to the user
 
-        .. note::
-            - If `eat` is ``False``, there is a chance that ``message`` variable is present.
-            - While it is recommended to be manually called, this will still be automatically called
-              if this isn't called but :meth:`.send()` is called.
-
-        :param eat: Whether to eat user's input. Default ``False``.
+        :param hidden: Whether the deffered response should be ephemeral . Default ``False``.
         """
-        base = {"type": 2 if eat else 5}
-        _task = self.bot.loop.create_task(self._http.post(base, self.interaction_id, self.__token, True))
-        self.sent = True
-        if not eat and (not self.guild_id or (self.channel and self.channel.permissions_for(self.guild.me).view_channel)):
-            with suppress(asyncio.TimeoutError):
-                def check(message: discord.Message):
-                    user_id = self.author_id
-                    is_author = message.author.id == user_id
-                    channel_id = self.channel_id
-                    is_channel = channel_id == message.channel.id
-                    is_user_input = message.type == 20
-                    is_correct_command = message.content.startswith(f"</{self.name}:{self.command_id}>")
-                    return is_author and is_channel and is_user_input and is_correct_command
-
-                self.message = await self.bot.wait_for("message", timeout=3, check=check)
-        await _task
-
-    @property
-    def ack(self):
-        """Alias of :meth:`.respond`."""
-        return self.respond
+        base = {"type": 5}
+        if hidden:
+            base["data"] = {"flags": 64}
+            self._deffered_hidden = True
+        await self._http.post_initial_response(base, self._interaction_id, self.__token)
+        self._deffered = True
 
     async def send(self,
                    content: str = "", *,
@@ -129,6 +112,7 @@ class SlashContext:
         .. warning::
             - Since Release 1.0.9, this is completely changed. If you are migrating from older version, please make sure to fix the usage.
             - You can't use both ``embed`` and ``embeds`` at the same time, also applies to ``file`` and ``files``.
+            - You cannot send files in the initial response
 
         :param content:  Content of the response.
         :type content: str
@@ -152,13 +136,6 @@ class SlashContext:
         """
         if isinstance(content, int) and 2 <= content <= 5:
             raise error.IncorrectFormat("`.send` Method is rewritten at Release 1.0.9. Please read the docs and fix all the usages.")
-        if not self.sent:
-            self.logger.info(f"At command `{self.name}`: It is recommended to call `.respond()` first!")
-            await self.respond(eat=hidden)
-        if hidden:
-            if embeds or embed or files or file:
-                self.logger.warning("Embed/File is not supported for `hidden`!")
-            return await self.send_hidden(content)
         if embed and embeds:
             raise error.IncorrectFormat("You can't use both `embed` and `embeds`!")
         if embed:
@@ -180,8 +157,31 @@ class SlashContext:
             "allowed_mentions": allowed_mentions.to_dict() if allowed_mentions
             else self.bot.allowed_mentions.to_dict() if self.bot.allowed_mentions else {}
         }
+        if hidden:
+            if embeds or files:
+                self._logger.warning("Embed/File is not supported for `hidden`!")
+            base["flags"] = 64
+        
+        initial_message = False
+        if not self._sent:
+            initial_message = True
+            if files:
+                raise error.IncorrectFormat("You cannot send files in the initial response!")
+            if self._deffered:
+                if self._deffered_hidden != hidden:
+                    self._logger.warning(
+                        "Deffered response might not be what you set it to! (hidden / visible) "
+                        "This is because it was deffered in a different state"
+                    )
+                resp = await self._http.edit(base, self.__token)
+                self._deffered = False
+            else:
+                base["type"] = 4
+                resp = await self._http.post_initial_response(base, self._interaction_id, self.__token)
+            self._sent = True
+        else:
+            resp = await self._http.post_followup(base, self.__token, files=files)
 
-        resp = await self._http.post(base, self.interaction_id, self.__token, files=files)
         smsg = model.SlashMessage(state=self.bot._connection,
                                   data=resp,
                                   channel=self.channel or discord.Object(id=self.channel_id),
@@ -189,18 +189,6 @@ class SlashContext:
                                   interaction_token=self.__token)
         if delete_after:
             self.bot.loop.create_task(smsg.delete(delay=delete_after))
+        if initial_message:
+            self.message = smsg
         return smsg
-
-    def send_hidden(self, content: str = ""):
-        """
-        Sends hidden response.\n
-        This is automatically used if you pass ``hidden=True`` at :meth:`.send`.
-
-        :param content: Message content.
-        :return: Coroutine
-        """
-        base = {
-            "content": content,
-            "flags": 64
-        }
-        return self._http.post(base, self.interaction_id, self.__token)

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -136,8 +136,6 @@ class SlashContext:
         :type delete_after: float
         :return: Union[discord.Message, dict]
         """
-        if isinstance(content, int) and 2 <= content <= 5:
-            raise error.IncorrectFormat("`.send` Method is rewritten at Release 1.0.9. Please read the docs and fix all the usages.")
         if embed and embeds:
             raise error.IncorrectFormat("You can't use both `embed` and `embeds`!")
         if embed:

--- a/discord_slash/error.py
+++ b/discord_slash/error.py
@@ -54,3 +54,8 @@ class IncorrectType(SlashCommandError):
     """
     Type passed was incorrect
     """
+
+class AlreadyResponded(SlashCommandError):
+    """
+    The interaction was already responded to
+    """

--- a/discord_slash/http.py
+++ b/discord_slash/http.py
@@ -3,6 +3,7 @@ import typing
 import aiohttp
 import discord
 from discord.http import Route
+from . import error
 
 
 class CustomRoute(Route):
@@ -78,39 +79,64 @@ class SlashCommandRequest:
         route = CustomRoute(method, url)
         return self._discord.http.request(route, **kwargs)
 
-    def post(self, _resp, interaction_id, token, initial=False, files: typing.List[discord.File] = None):
+    def post_followup(self, _resp, token, files: typing.List[discord.File] = None):
         """
-        Sends command response POST request to Discord API.
+        Sends command followup response POST request to Discord API.
 
         :param _resp: Command response.
         :type _resp: dict
-        :param interaction_id: Interaction ID.
         :param token: Command message token.
-        :param initial: Whether this request is initial. Default ``False``
         :param files: Files to send. Default ``None``
         :type files: List[discord.File]
         :return: Coroutine
         """
         if files:
             return self.post_with_files(_resp, files, token)
-        req_url = f"/interactions/{interaction_id}/{token}/callback" if initial else f"/webhooks/{self._discord.user.id}/{token}"
-        route = CustomRoute("POST", req_url)
-        return self._discord.http.request(route, json=_resp)
+        return self.command_response(token, True, "POST", json=_resp)
+
+    def post_initial_response(self, _resp, interaction_id, token):
+        """
+        Sends an initial "POST" response to the Discord API.
+         
+        :param _resp: Command response.
+        :type _resp: dict
+        :param interaction_id: Interaction ID.
+        :param token: Command message token.
+        :return: Coroutine
+        """
+        return self.command_response(token, False, "POST", interaction_id, json=_resp)
+
+    def command_response(self, token, use_webhook, method, interaction_id= None, url_ending = "", **kwargs):
+        """
+        Sends a command response to discord (POST, PATCH, DELETE)
+
+        :param token: Interaction token
+        :param use_webhook: Whether to use webhooks
+        :param method: The HTTP request to use
+        :param interaction_id: The id of the interaction
+        :param url_ending: String to append onto the end of the url.
+        :param \**kwargs: Kwargs to pass into discord.py's `request function <https://github.com/Rapptz/discord.py/blob/master/discord/http.py#L134>`_
+        :return: Coroutine
+        """
+        if not use_webhook and not interaction_id:
+            raise error.IncorrectFormat("Internal Error! interaction_id must be set if use_webhook is False")
+        req_url = f"/webhooks/{self._discord.user.id}/{token}" if use_webhook else f"/interactions/{interaction_id}/{token}/callback"
+        req_url += url_ending
+        route = CustomRoute(method, req_url)
+        return self._discord.http.request(route, **kwargs)
 
     def post_with_files(self, _resp, files: typing.List[discord.File], token):
-        req_url = f"/webhooks/{self._discord.user.id}/{token}"
-        route = CustomRoute("POST", req_url)
         form = aiohttp.FormData()
         form.add_field("payload_json", json.dumps(_resp))
         for x in range(len(files)):
             name = f"file{x if len(files) > 1 else ''}"
             sel = files[x]
             form.add_field(name, sel.fp, filename=sel.filename, content_type="application/octet-stream")
-        return self._discord.http.request(route, data=form, files=files)
+        return self.command_response(token, True, "POST", data=form, files=files)
 
     def edit(self, _resp, token, message_id="@original"):
         """
-        Sends edit command response POST request to Discord API.
+        Sends edit command response PATCH request to Discord API.
 
         :param _resp: Edited response.
         :type _resp: dict
@@ -118,9 +144,8 @@ class SlashCommandRequest:
         :param message_id: Message ID to edit. Default initial message.
         :return: Coroutine
         """
-        req_url = f"/webhooks/{self._discord.user.id}/{token}/messages/{message_id}"
-        route = CustomRoute("PATCH", req_url)
-        return self._discord.http.request(route, json=_resp)
+        req_url = f"/messages/{message_id}"
+        return self.command_response(token, True, "PATCH", url_ending = req_url, json=_resp)
 
     def delete(self, token, message_id="@original"):
         """
@@ -130,6 +155,5 @@ class SlashCommandRequest:
         :param message_id: Message ID to delete. Default initial message.
         :return: Coroutine
         """
-        req_url = f"/webhooks/{self._discord.user.id}/{token}/messages/{message_id}"
-        route = CustomRoute("DELETE", req_url)
-        return self._discord.http.request(route)
+        req_url = f"/messages/{message_id}"
+        return self.command_response(token, True, "DELETE", url_ending = req_url)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -109,7 +109,7 @@ Pretty much anything from the discord's commands extension doesn't work, also so
 .. warning::
    If you use something that might take a while, eg ``wait_for`` you'll run into two issues:
 
-   1. If you don't respond within 3 seconds (``ctx.respond()``) discord invalidates the interaction.
+   1. If you don't respond within 3 seconds (``ctx.defer()`` or `ctx.send(..)``) discord invalidates the interaction.
    2. The interaction only lasts for 15 minutes, so if you try and send something with the interaction (``ctx.send``) more than 15 mins after the command was ran it won't work.
 
    As an alternative you can use ``ctx.channel.send`` but this relies on the the bot being in the guild, and the bot having send perms in that channel.

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -54,17 +54,12 @@ code as shown below:
   @slash.slash(name="test",
                description="This is just a test command, nothing more.")
   async def test(ctx):
-    await ctx.respond()
     await ctx.send(content="Hello World!")
     
 Now that we've gone over how Discord handles the declaration of slash commands
 through their Bot API, let's go over what some of the other things mean within
 the *logical* part of our code, the command function:
 
-- ``ctx.respond()``: This is a way for us to handle responses. In short, the API
-requires some way to "acknowledge" an interaction response that we want to send off.
-
-(An alias of this would be ``ctx.ack()``)
 
 Giving some options for variety.
 --------------------------------
@@ -163,7 +158,6 @@ Now, we can finally visualize this by coding an example of this being used in th
                  )
                ])
   async def test(ctx, optone: str):
-    await ctx.respond()
     await ctx.send(content=f"I got you, you said {optone}!")
     
 Additionally, we could also declare the type of our command's option through this method shown here:
@@ -233,7 +227,6 @@ a string or integer. Below is an implementation of this design in the Python cod
                  )
                ])
   async def test(ctx, optone: str):
-    await ctx.respond()
     await ctx.send(content=f"Wow, you actually chose {optone}? :(")
 
 .. _quickstart: https://discord-py-slash-command.readthedocs.io/en/latest/quickstart.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ discussion on GitHub!
 
    quickstart.rst
    gettingstarted.rst
-   migrate_to_109.rst
+   migration.rst
    discord_slash.rst
    events.rst
    discord_slash.utils.rst

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -51,8 +51,9 @@ Sending hidden messages
 ***********************
 The method ``.send_hidden`` on :class:`SlashContext` has been removed. Use ``.send(hidden = True, ..)`` instead.
 
-
-
+SlashContext
+************
+``ctx.sent`` has been renamed to :attr:`ctx.responded <.SlashContext.responded>`
 
 
 Migrate To 1.0.9

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,3 +1,60 @@
+Migration
++++++++++
+This page contains instructions on how to migrate between versions with breaking changes.
+
+Migrate To V1.0.10
+==================
+Changes that you'll need to make in this version are mainly becuase of a new ui from discord, more info `here <https://github.com/discord/discord-api-docs/pull/2615>`_
+
+Responding / Deferring
+**********************
+
+In regards to :class:`SlashContext` the methods ``.respond`` and ``.ack`` have been removed, and ``.defer`` added. 
+Deferring a message will allow you to respond for up to 15 mins, but you'll have to defer within three seconds.
+When you defer the user will see a "this bot is thinking" message until you send a message, This message can be ephermical (hidden) or visible.
+``.defer`` has a ``hidden`` parameter, which will make the deferred message ephermical.
+
+We suggest deferring if you might take more than three seconds to respond, but if you will call ``.send`` before three seconds then don't.
+
+.. note::
+    You **must** respond with ``.send`` within 15 minutes of the command being invoked to avoid an "interaction failed" message, if you defer.
+    This is especially relevant for bots that had 'invisible' commands, where the invocation was not shown.
+    If you wish to have the invocation of the command not visible, send an ephermical success message, and then do what you used to.
+    It is no longer possible to "eat" the invocation.
+    ``ctx.channel.send`` does **not** count as responding.
+
+Example
+--------
+
+.. code-block:: python
+
+    # Before
+    @slash.slash(...)
+    async def command(ctx, ...):
+        await ctx.respond()
+        await ctx.send(...)
+    
+    # After 1
+    @slash.slash(...)
+    async def command(ctx, ...):
+        await ctx.send(...)
+
+    # After 2
+    @slash.slash(...)
+    async def command(ctx, ...):
+        await ctx.defer()
+        # Process that takes time
+        await ctx.send(...)
+
+    
+Sending hidden messages
+***********************
+The method ``.send_hidden`` on :class:`SlashContext` has been removed. Use ``.send(hidden = True, ..)`` instead.
+
+
+
+
+
 Migrate To 1.0.9
 ================
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -52,7 +52,6 @@ slash commands just yet. We can do that by adding this code shown here:
 
     @slash.slash(name="ping", guild_ids=guild_ids)
     async def _ping(ctx): # Defines a new "context" (ctx) command called "ping."
-        await ctx.respond()
         await ctx.send(f"Pong! ({client.latency*1000}ms)")
 
 Let's compare some of the major code differences between the prior examples in order

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,7 +56,7 @@ slash commands just yet. We can do that by adding this code shown here:
 
 .. note::
     In this example we responded directly to the interaction, however if you want to delay the response (if you need more than 3 seconds before sending a message)
-    you can defer the response for up to 15 miniuties with :meth:`ctx.defer() <.SlashContext.defer()>`, this displays a "Bot is thinking" message.
+    you can defer the response for up to 15 minutes with :meth:`ctx.defer() <.SlashContext.defer()>`, this displays a "Bot is thinking" message.
     However do not defer the response if you will be able to respond (send) within three seconds as this will cause a message to flash up
 
 Let's compare some of the major code differences between the prior examples in order

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -54,6 +54,11 @@ slash commands just yet. We can do that by adding this code shown here:
     async def _ping(ctx): # Defines a new "context" (ctx) command called "ping."
         await ctx.send(f"Pong! ({client.latency*1000}ms)")
 
+.. note::
+    In this example we responded directly to the interaction, however if you want to delay the response (if you need more than 3 seconds before sending a message)
+    you can defer the response for up to 15 miniuties with :meth:`ctx.defer() <.SlashContext.defer()>`, this displays a "Bot is thinking" message.
+    However do not defer the response if you will be able to respond (send) within three seconds as this will cause a message to flash up
+
 Let's compare some of the major code differences between the prior examples in order
 to explain what's going on here:
 


### PR DESCRIPTION
## About this pull request

This pr implements the upcoming UI changes [#2615](https://github.com/discord/discord-api-docs/pull/2615)  
I will leave it as a draft until I am able to test it (discord releases the changes)

## Changes

- Reworked `http` for clarity in context.py
- Removed `respond`, `ack`, and `send_hidden`
- Added `defer`
- Edited `send` to:
  - Check if it's currently deffered, and if so edit it
  - Check if nothing has been sent, and if so respond with type 4
- Set `.message` to the response from either the edit to the initial response or the initial response
- Added a new error `AlreadyResponded` which is raised if `ctx.defer()` is called when the message was already responded to

I have added a warning if the `hidden` value, passed to `send` immeditally after being deffered, if different to the `hidden` value passed to `defer`. 
This is because currently I'm assuming that you can't change the 'state' of the message after responding initially.
I have asked [here](https://github.com/discord/discord-api-docs/pull/2615#issuecomment-783291122)

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [x] There is/are breaking change(s).
- [x] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)

Note: I could not test this code as discord has not released the features yet
