### PR TITLE
make lib able to import with discord.ext.slash

### DIFF
--- a/discord/ext/slash.py
+++ b/discord/ext/slash.py
@@ -1,0 +1,1 @@
+from discord_slash import *

--- a/discord/ext/slash.py
+++ b/discord/ext/slash.py
@@ -1,1 +1,5 @@
-from discord_slash import *
+from discord_slash.client import SlashCommand
+from discord_slash.model import SlashCommandOptionType
+from discord_slash.context import SlashContext
+from discord_slash.utils import manage_commands
+from discord_slash import client, cog_ext, context, error, http, model

--- a/discord/ext/slash.py
+++ b/discord/ext/slash.py
@@ -1,5 +1,1 @@
-from discord_slash.client import SlashCommand
-from discord_slash.model import SlashCommandOptionType
-from discord_slash.context import SlashContext
-from discord_slash.utils import manage_commands
-from discord_slash import client, cog_ext, context, error, http, model
+from discord_slash import *  # noqa: F401, F403

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -56,6 +56,9 @@ the many subclasses offered in *discord-py-slash-command*.
   import discord
   from discord_slash import SlashCommand
   from discord_slash.utils import manage_commands # Allows us to manage the command settings.
+  # You can use these instead:
+  # from discord.ext.slash import SlashCommand
+  # from discord.ext.slash.utils import manage_commands
 
   client = discord.Client(intents=discord.Intents.all())
   slash = SlashCommand(client, sync_commands=True)


### PR DESCRIPTION
## About this pull request

Many discord.py extension can be imported like this script:
```python
from discord.ext import something
```

So I made this lib able to be imported like this.

## Changes

- Added discord/ext/slash.py

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
