### PR TITLE
Add override for the application ID in order to support legacy applications

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -45,12 +45,13 @@ class SlashCommand:
                  sync_commands: bool = False,
                  delete_from_unused_guilds: bool = False,
                  sync_on_cog_reload: bool = False,
-                 override_type: bool = False):
+                 override_type: bool = False,
+                 application_id: typing.Optional[int] = None):
         self._discord = client
         self.commands = {}
         self.subcommands = {}
         self.logger = logging.getLogger("discord_slash")
-        self.req = http.SlashCommandRequest(self.logger, self._discord)
+        self.req = http.SlashCommandRequest(self.logger, self._discord, application_id)
         self.sync_commands = sync_commands
         self.sync_on_cog_reload = sync_on_cog_reload
 


### PR DESCRIPTION
## About this pull request

Allows users to manually specify the application ID, rather than having the library attempt to derive it from the bot's user ID. This is important for legacy bots where the application ID and bot user ID are not the same.

## Changes

Adds an `application_id` argument to `SlashCommand` in order to manually specify the application ID. Changes are non-breaking.

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #108, #112 
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
