### PR TITLE
Fix incorrect example.

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -170,11 +170,11 @@ Additionally, we could also declare the type of our command's option through thi
 
 .. code-block:: python
 
-  from discord_slash.model import SubCommandOptionType
+  from discord_slash.model import SlashCommandOptionType
   
   (...)
   
-                  option_type=SubCommandOptionType.STRING
+                  option_type=SlashCommandOptionType.STRING
                   
 More in the option? Give them a choice.
 ---------------------------------------


### PR DESCRIPTION
## About this pull request

Incorrect example of slash command enum was given, this should fix it.

## Changes

.RST Getting Started change.

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [X] (If required) Relavent documentation has been updated/added.
- [X] This is not a code change. (README, docs, etc.)
