### PR TITLE
Add kwargs and args attrs to context

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -691,12 +691,15 @@ class SlashCommand:
         try:
             not_kwargs = False
             if isinstance(args, dict):
+                ctx.kwargs = args
+                ctx.args = list(args.values())
                 try:
                     await func.invoke(ctx, **args)
                 except TypeError:
                     args = list(args.values())
                     not_kwargs = True
             else:
+                ctx.args = args
                 not_kwargs = True
             if not_kwargs:
                 await func.invoke(ctx, *args)

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -18,6 +18,8 @@ class SlashContext:
 
     :ivar message: Message that invoked the slash command.
     :ivar name: Name of the command.
+    :ivar args: List of processed arguments invoked with the command.
+    :ivar kwargs: Dictionary of processed arguments invoked with the command.
     :ivar subcommand_name: Subcommand of the command.
     :ivar subcommand_group: Subcommand group of the command.
     :ivar interaction_id: Interaction ID of the command message.
@@ -40,6 +42,8 @@ class SlashContext:
         self.__token = _json["token"]
         self.message = None # Should be set later.
         self.name = self.command = self.invoked_with = _json["data"]["name"]
+        self.args = []
+        self.kwargs = {}
         self.subcommand_name = self.invoked_subcommand = self.subcommand_passed = None
         self.subcommand_group = self.invoked_subcommand_group = self.subcommand_group_passed = None
         self.interaction_id = _json["id"]


### PR DESCRIPTION
## About this pull request

This adds the attributes `args` and `kwargs` to `SlashContext`

Wasn't sure if `args` should be the values or keys of `kwargs`, but assumed it would be values?

## Changes

Add empty `.args = []` and `.kwargs = {}` to `SlashContext`
Set both in `invoke_command`

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`. # again laptop being annoying so no
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Resolves #115 
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
