### PR TITLE
Make commandObjects inherit from discord.ext.commands

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -701,6 +701,13 @@ class SlashCommand:
             if not_kwargs:
                 await func.invoke(ctx, *args)
         except Exception as ex:
+
+            if hasattr(func, "on_error"):
+                # support error decorator
+                try:
+                    await func.on_error(ctx, ex)
+                except Exception as e:
+                    logging.error(f"{ctx.command}:: Error using error decorator: {e}")
             await self.on_slash_command_error(ctx, ex)
 
     async def on_socket_response(self, msg):

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -3,6 +3,8 @@ import asyncio
 import discord
 from contextlib import suppress
 from discord.ext import commands
+from discord.utils import snowflake_time
+
 from . import http
 from . import error
 from . import model
@@ -57,6 +59,7 @@ class SlashContext:
             self.author = discord.User(data=_json["member"]["user"], state=self.bot._connection)
         else:
             self.author = discord.User(data=_json["user"], state=self.bot._connection)
+        self.created_at = snowflake_time(int(self.interaction_id))  # the time this interaction was created
 
     @property
     def guild(self) -> typing.Optional[discord.Guild]:

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -95,6 +95,9 @@ class CommandObject(commands.Command):
             return f"{self.base} {group}{self.name}"
         return self.name
 
+    def __call__(self, *args, **kwargs):
+        raise NotImplementedError("Please use SlashContext.InvokeCommand")
+
     @property
     def full_parent_name(self):
         """:class:`str`: Retrieves the fully qualified parent command name.

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -19,6 +19,7 @@ from . import error
 class CommandObject(commands.Command):
     """
     Slash command object of this extension.
+    This is based on discord.ext.commands.Command, certain methods have been overridden / disabled to work with slash
 
     .. warning::
         Do not manually init this model.
@@ -96,6 +97,9 @@ class CommandObject(commands.Command):
         return self.name
 
     def __call__(self, *args, **kwargs):
+
+        # context contains a method that is far better suited to invoking slash commands
+        # so in order to remove potential bugs with this method, ive disabled it
         raise NotImplementedError("Please use SlashContext.InvokeCommand")
 
     @property
@@ -257,7 +261,7 @@ class CogCommandObject(CommandObject):
         """
         await self.prepare(args[0])
 
-        injected = hooked_wrapped_callback(self.func, args[0], self.callback)
+        injected = hooked_wrapped_callback(self, args[0], self.callback)
         return await injected(self.cog, *args, **kwargs)
 
 
@@ -282,7 +286,7 @@ class CogSubcommandObject(SubcommandObject):
         """
         await self.prepare(args[0])
 
-        injected = hooked_wrapped_callback(self.func, args[0], self.callback)
+        injected = hooked_wrapped_callback(self, args[0], self.callback)
         return await injected(self.cog, *args, **kwargs)
 
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -207,7 +207,6 @@ class CommandObject(commands.Command):
 
         if self.cog:
             # handle cog commands without override
-            await self.prepare(args[0])
 
             injected = hooked_wrapped_callback(self, args[0], self.callback)
             return await injected(self.cog, *args, **kwargs)

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 from contextlib import suppress
-from copy import deepcopy
 from enum import IntEnum
 
 import discord
@@ -63,12 +62,12 @@ class CommandObject(commands.Command):
         self.__original_kwargs__ = kwargs.copy()
 
         # dpy slash uses args as well, so to avoid breaking, ive added this line
-        self.__original_args__ = deepcopy(args)
+        self.__original_args__ = args
         return self
 
     def copy(self):
         ret = self.__class__(*self.__original_args__, **self.__original_kwargs__)
-        return ret
+        return self._ensure_assignment_on_copy(ret)
 
     def update(self, **kwargs):
         """Updates :class:`Command` instance with updated attribute.


### PR DESCRIPTION
# ===This is not ready for merging===

## About this pull request

Modifies all command objects to inherit from dpy commands ext commands. This allows people to use the decorators and functions provided by command objects

## Changes

- Rebuilt command objects to use `discord.ext.commands.command` as their base
- Added call in `invoke_command` to trigger error decorator if present 

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [x] There is/are breaking change(s).
- [ ] (If required) Relavent documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)

## Checklist of functionality
This is a checklist of functionality that has been ported to work with slash command objects. My intent is to get as many of these to work as possible before merging 

- [x] Error decorators
- [x] Cooldown decorators
- [x] Before & after invoke decorators
- [ ] `add_check` method
- [x] `call` method
- [ ] `copy` method
- [x] `get_cooldown_retry_after`
- [x] `reset_cooldown`
- [ ] `update`
- [x] Attributes -- see [dpy](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html#discord.ext.commands.Command)