### PR TITLE
Implement files in editing messages

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -171,15 +171,15 @@ class SlashContext:
         initial_message = False
         if not self.responded:
             initial_message = True
-            if files:
-                raise error.IncorrectFormat("You cannot send files in the initial response!")
+            if files and not self.deffered:
+                await self.defer(hidden=hidden)
             if self.deffered:
                 if self._deffered_hidden != hidden:
                     self._logger.warning(
                         "Deffered response might not be what you set it to! (hidden / visible) "
                         "This is because it was deffered in a different state"
                     )
-                resp = await self._http.edit(base, self.__token)
+                resp = await self._http.edit(base, self.__token, files = files)
                 self.deffered = False
             else:
                 json_data = {

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -193,10 +193,8 @@ class SlashContext:
         initial_message = False
         if not self.responded:
             initial_message = True
-            if files and not self.defered:
+            if files and not self.deferred:
                 await self.defer(hidden=hidden)
-            if self.defered:
-                if self._defered_hidden != hidden:
             if self.deferred:
                 if self._deferred_hidden != hidden:
                     self._logger.warning(
@@ -204,8 +202,6 @@ class SlashContext:
                         "This is because it was deferred in a different state"
                     )
                 resp = await self._http.edit(base, self.__token, files = files)
-                self.defered = False
-                resp = await self._http.edit(base, self.__token)
                 self.deferred = False
             else:
                 json_data = {

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -118,7 +118,7 @@ class SlashContext:
         .. warning::
             - Since Release 1.0.9, this is completely changed. If you are migrating from older version, please make sure to fix the usage.
             - You can't use both ``embed`` and ``embeds`` at the same time, also applies to ``file`` and ``files``.
-            - You cannot send files in the initial response
+            - If you send files in the initial response, this will defer if it's not been deferred, and then PATCH with the message
 
         :param content:  Content of the response.
         :type content: str

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -197,8 +197,6 @@ class SlashContext:
                 await self.defer(hidden=hidden)
             if self.defered:
                 if self._defered_hidden != hidden:
-            if files:
-                raise error.IncorrectFormat("You cannot send files in the initial response!")
             if self.deferred:
                 if self._deferred_hidden != hidden:
                     self._logger.warning(

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -194,6 +194,9 @@ class SlashContext:
             self.responded = True
         else:
             resp = await self._http.post_followup(base, self.__token, files=files)
+        if files:
+            for file in files:
+                file.close()
         if not hidden:
             smsg = model.SlashMessage(state=self.bot._connection,
                                       data=resp,

--- a/discord_slash/http.py
+++ b/discord_slash/http.py
@@ -96,7 +96,7 @@ class SlashCommandRequest:
         :return: Coroutine
         """
         if files:
-            return self.post_with_files(_resp, files, token)
+            return self.request_with_files(_resp, files, token, "POST")
         return self.command_response(token, True, "POST", json=_resp)
 
     def post_initial_response(self, _resp, interaction_id, token):
@@ -130,7 +130,7 @@ class SlashCommandRequest:
         route = CustomRoute(method, req_url)
         return self._discord.http.request(route, **kwargs)
 
-    def post_with_files(self, _resp, files: typing.List[discord.File], token):
+    def request_with_files(self, _resp, files: typing.List[discord.File], token, method, url_ending = ""):
 
         form = aiohttp.FormData()
         form.add_field("payload_json", json.dumps(_resp))
@@ -138,9 +138,9 @@ class SlashCommandRequest:
             name = f"file{x if len(files) > 1 else ''}"
             sel = files[x]
             form.add_field(name, sel.fp, filename=sel.filename, content_type="application/octet-stream")
-        return self.command_response(token, True, "POST", data=form, files=files)
+        return self.command_response(token, True, method, data=form, files=files, url_ending=url_ending)
 
-    def edit(self, _resp, token, message_id="@original"):
+    def edit(self, _resp, token, message_id="@original", files: typing.List[discord.File] = None):
         """
         Sends edit command response PATCH request to Discord API.
 
@@ -148,9 +148,13 @@ class SlashCommandRequest:
         :type _resp: dict
         :param token: Command message token.
         :param message_id: Message ID to edit. Default initial message.
+        :param files: Files. Default ``None``
+        :type files: List[discord.File]
         :return: Coroutine
         """
         req_url = f"/messages/{message_id}"
+        if files:
+            return self.request_with_files(_resp, files, token, "PATCH", url_ending = req_url)
         return self.command_response(token, True, "PATCH", url_ending = req_url, json=_resp)
 
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -200,7 +200,7 @@ class SlashMessage(discord.Message):
         """
         _resp = {}
 
-        content = str(fields.get("content"))
+        content = fields.get("content")
         if content:
             _resp["content"] = str(content)
 
@@ -240,7 +240,7 @@ class SlashMessage(discord.Message):
 
     async def edit(self, **fields):
         """Refer :meth:`discord.Message.edit`."""
-        if ("file", "files") in fields:
+        if "file" in fields or "files" in fields:
             await self._slash_edit(**fields)
         else:
             try:

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -194,7 +194,7 @@ class SlashMessage(discord.Message):
         self._http = _http
         self.__interaction_token = interaction_token
 
-    async def _slash_edit(self, **kwargs):
+    async def _slash_edit(self, **fields):
         """
         An internal function
         """
@@ -225,7 +225,7 @@ class SlashMessage(discord.Message):
         _resp["allowed_mentions"] = allowed_mentions.to_dict() if allowed_mentions else \
             self._state.allowed_mentions.to_dict() if self._state.allowed_mentions else {}
 
-        await self._http.edit(_resp, self.__interaction_token, self.id, files = files)
+        await self._http.edit(_resp, self.__interaction_token, self.id, files = fileso)
 
         delete_after = fields.get("delete_after")
         if delete_after:

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -233,6 +233,9 @@ class SlashMessage(discord.Message):
         delete_after = fields.get("delete_after")
         if delete_after:
             await self.delete(delay=delete_after)
+        if files:
+            for file in files:
+                file.close()
 
 
     async def edit(self, **fields):

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -206,6 +206,9 @@ class SlashMessage(discord.Message):
 
         embed = fields.get("embed")
         embeds = fields.get("embeds")
+        file = fields.get("file")
+        files = fields.get("files")
+
         if embed and embeds:
             raise error.IncorrectFormat("You can't use both `embed` and `embeds`!")
         if file and files:
@@ -225,7 +228,7 @@ class SlashMessage(discord.Message):
         _resp["allowed_mentions"] = allowed_mentions.to_dict() if allowed_mentions else \
             self._state.allowed_mentions.to_dict() if self._state.allowed_mentions else {}
 
-        await self._http.edit(_resp, self.__interaction_token, self.id, files = fileso)
+        await self._http.edit(_resp, self.__interaction_token, self.id, files = files)
 
         delete_after = fields.get("delete_after")
         if delete_after:
@@ -234,10 +237,13 @@ class SlashMessage(discord.Message):
 
     async def edit(self, **fields):
         """Refer :meth:`discord.Message.edit`."""
-        try:
-            await super().edit(**fields)
-        except discord.Forbidden:
-           await self._slash_edit(**fields)
+        if ("file", "files") in fields:
+            await self._slash_edit(**fields)
+        else:
+            try:
+                await super().edit(**fields)
+            except discord.Forbidden:
+                await self._slash_edit(**fields)
 
     async def delete(self, *, delay=None):
         """Refer :meth:`discord.Message.delete`."""


### PR DESCRIPTION
## About this pull request

This implements files while editing messages, and sending files in the initial response

## Changes

What changes were made?

Changes to `SlashMessage.edit` and edit in http to allow editing for files
Changed the behavior of `SlashContext.send` to defer and then patch if files are included for the initial response.

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
