### PR TITLE
Removes getdoc  from command registration

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -413,7 +413,6 @@ class SlashCommand:
         subcommand_group = subcommand_group.lower() if subcommand_group else subcommand_group
         name = name or cmd.__name__
         name = name.lower()
-        description = description
         guild_ids = guild_ids if guild_ids else []
 
         if base in self.commands:

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -2,7 +2,7 @@ import copy
 import logging
 import typing
 import discord
-from inspect import iscoroutinefunction, getdoc
+from inspect import iscoroutinefunction
 from contextlib import suppress
 from discord.ext import commands
 from . import http
@@ -358,9 +358,6 @@ class SlashCommand:
             for x in tgt.allowed_guild_ids:
                 if x not in guild_ids:
                     guild_ids.append(x)
-
-        description = description or getdoc(cmd)
-
         if options is None:
             options = manage_commands.generate_options(cmd, description, connector)
 
@@ -416,7 +413,7 @@ class SlashCommand:
         subcommand_group = subcommand_group.lower() if subcommand_group else subcommand_group
         name = name or cmd.__name__
         name = name.lower()
-        description = description or getdoc(cmd)
+        description = description
         guild_ids = guild_ids if guild_ids else []
 
         if base in self.commands:


### PR DESCRIPTION
## About this pull request

If the description param isn't specified, the library will fall back to using doc strings as the command description. If the doc string is over the char limit for descriptions, it will cause syncing to fail. 

Expected behaviour of the library would be to use the description param, or "No description".

Technically breaking as someone could be using this behaviour
## Changes

Removed getdoc

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [x] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
