### PR TITLE
Remove disclaimer link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 <p align="center">
    <a href="#about">About</a> ⦿
    <a href="#installation">Installation</a> ⦿
-   <a href="#disclaimer">Disclaimer</a> ⦿
    <a href="#examples">Examples</a> ⦿
    <a href="https://discord-py-slash-command.readthedocs.io/en/latest/">Documentation</a> ⦿
    <a href="https://discord.gg/KkgMBVuEkx">Discord Server</a>


### PR DESCRIPTION
Disclaimer was removed after the official release but the header link was still in the readme


- [x] This is not a code change. (README, docs, etc.)
