### PR TITLE
Updated The Sync_Commands=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ from discord.ext import commands
 from discord_slash import SlashCommand
 
 bot = commands.Bot(command_prefix="prefix")
-slash = SlashCommand(bot, override_type = True)
+slash = SlashCommand(bot, sync_commands=True, sync_on_cog_reload=True)
 
 bot.load_extension("cog")
 bot.run("TOKEN")


### PR DESCRIPTION
The Overide_Type is useless, id the commands won't work without the Sync Commands Aspect.

## About this pull request

Description of the pr

## Changes

What changes were made?

## Checklist

- [ X] I've checked this pull request runs on `Python 3.6.X`.
- [ X] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [X ] This adds something new.
- [x] There is/are breaking change(s).
- [ X] (If required) Relevant documentation has been updated/added.
- [ X] This is not a code change. (README, docs, etc.)
