### PR TITLE
Remove outdated note regarding ephemeral messages

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -134,9 +134,6 @@ class SlashContext:
         """
         Sends response of the slash command.
 
-        .. note::
-            - Param ``hidden`` doesn't support embed and file.
-
         .. warning::
             - Since Release 1.0.9, this is completely changed. If you are migrating from older version, please make sure to fix the usage.
             - You can't use both ``embed`` and ``embeds`` at the same time, also applies to ``file`` and ``files``.

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -183,8 +183,6 @@ class SlashContext:
             else self.bot.allowed_mentions.to_dict() if self.bot.allowed_mentions else {}
         }
         if hidden:
-            if embeds or files:
-                self._logger.warning("Embed/File is not supported for `hidden`!")
             base["flags"] = 64
 
         initial_message = False


### PR DESCRIPTION
## About this pull request

Updates docstring in `SlashContext.send` to remove an outdated note, regarding embeds in ephemeral messages.
Closes #167 

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
