### PR TITLE
utils.manage_commands: Allow int values for create_choice

### DIFF
--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -5,6 +5,7 @@ import aiohttp
 from ..error import RequestFailure, IncorrectType
 from ..model import SlashCommandOptionType
 from collections.abc import Callable
+from typing import Union
 
 
 async def add_slash_command(bot_id,
@@ -223,7 +224,7 @@ def generate_options(function: Callable, description: str = "No description.", c
     return options
 
 
-def create_choice(value: str, name: str):
+def create_choice(value: Union[str, int], name: str):
     """
     Creates choices used for creating command option.
 


### PR DESCRIPTION
## About this pull request

Very small change that allows for either a string or integer value to be passed to `create_choice`, instead of only strings.

## Changes

- Changed type hint of `create_choice` to `Union[str, int]` instead of `str`

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
