### PR TITLE
Fix eunwoo1104/discord-py-slash-command#173

### DIFF
--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -336,7 +336,7 @@ class SlashMessage(discord.Message):
 
     async def edit(self, **fields):
         """Refer :meth:`discord.Message.edit`."""
-        if "file" in fields or "files" in fields:
+        if "file" in fields or "files" in fields or "embeds" in fields:
             await self._slash_edit(**fields)
         else:
             try:


### PR DESCRIPTION
## About this pull request

Fix #173

## Changes

Edit `discord_slash.model.SlashMessage.edit` to allow for the `embeds` kwarg to trigger `SlashMessage._slash_edit` instead of discord.py's message edit

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #173 
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
