### PR TITLE
More permissions docs fixes

### DIFF
--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -344,7 +344,7 @@ def create_multi_ids_permission(ids: typing.List[int], id_type: typing.Union[int
     """
     Creates a list of permissions from list of ids with common id_type and permission state.
 
-    :param id: List of target ids to apply the permission on.
+    :param ids: List of target ids to apply the permission on.
     :param id_type: Type of the id. 
     :param permission: State of the permission. ``True`` to allow access, ``False`` to disallow access.
     """


### PR DESCRIPTION
## About this pull request

As the title states ;)

## Changes

* Fix docsstring typo for create_multi_ids_permission.

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
