### PR TITLE
Update docs/quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -28,7 +28,7 @@ For this example, ``main.py`` will be used.
     from discord.ext import commands
     from discord_slash import SlashCommand # Importing the newly installed library.
 
-    bot = commands.Bot(command_prefix="/", intents=discord.Intents.all())
+    bot = commands.Bot(intents=discord.Intents.all())
     slash = SlashCommand(bot, sync_commands=True) # Declares slash commands through the client.
 
     @bot.event

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,16 +25,17 @@ For this example, ``main.py`` will be used.
 .. code-block:: python
 
     import discord
+    from discord.ext import commands
     from discord_slash import SlashCommand # Importing the newly installed library.
 
-    client = discord.Client(intents=discord.Intents.all())
-    slash = SlashCommand(client, sync_commands=True) # Declares slash commands through the client.
+    bot = commands.Bot(command_prefix="/", intents=discord.Intents.all())
+    slash = SlashCommand(bot, sync_commands=True) # Declares slash commands through the client.
 
-    @client.event
+    @bot.event
     async def on_ready():
         print("Ready!")
 
-    client.run("your_bot_token_here")
+    bot.run("your_bot_token_here")
 
 Let's give this a run. When you run this code, you'll see... nothing but ``Ready!``.
 
@@ -44,7 +45,7 @@ slash commands just yet. We can do that by adding this code shown here:
 .. code-block:: python
 
     """
-        Make sure this code is added before the client.run() call!
+        Make sure this code is added before the bot.run() call!
         It also needs to be under on_ready, otherwise, this will not work.
     """
     

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -25,17 +25,16 @@ For this example, ``main.py`` will be used.
 .. code-block:: python
 
     import discord
-    from discord.ext import commands
     from discord_slash import SlashCommand # Importing the newly installed library.
 
-    bot = commands.Bot(intents=discord.Intents.all())
-    slash = SlashCommand(bot, sync_commands=True) # Declares slash commands through the client.
+    client = discord.Client(intents=discord.Intents.all())
+    slash = SlashCommand(client, sync_commands=True) # Declares slash commands through the client.
 
-    @bot.event
+    @client.event
     async def on_ready():
         print("Ready!")
 
-    bot.run("your_bot_token_here")
+    client.run("your_bot_token_here")
 
 Let's give this a run. When you run this code, you'll see... nothing but ``Ready!``.
 
@@ -45,7 +44,7 @@ slash commands just yet. We can do that by adding this code shown here:
 .. code-block:: python
 
     """
-        Make sure this code is added before the bot.run() call!
+        Make sure this code is added before the client.run() call!
         It also needs to be under on_ready, otherwise, this will not work.
     """
     
@@ -54,6 +53,38 @@ slash commands just yet. We can do that by adding this code shown here:
     @slash.slash(name="ping", guild_ids=guild_ids)
     async def _ping(ctx): # Defines a new "context" (ctx) command called "ping."
         await ctx.send(f"Pong! ({client.latency*1000}ms)")
+
+If you are using commands.Bot instead and want both discord.py commands and slash commands, you can do this:
+
+.. code-block:: python
+
+    import discord
+    from discord.ext import commands
+    from discord_slash import SlashCommand # Importing the newly installed library.
+
+    bot = commands.Bot(command_prefix=".", intents=discord.Intents.all()) # Choose your own prefix.
+    slash = SlashCommand(bot, sync_commands=True) # Declares slash commands through the client.
+
+    @bot.event
+    async def on_ready():
+        print("Ready!")
+
+    """
+        Make sure the code below is added before the bot.run() call!
+        It also needs to be under on_ready, otherwise, this will not work.
+    """
+    
+    @bot.command()
+    async def ping(ctx):
+        await ctx.send(f"Pong! ({bot.latency*1000}ms)")
+    
+    guild_ids = [789032594456576001] # Put your server ID in this array.
+
+    @slash.slash(name="ping", guild_ids=guild_ids)
+    async def _ping(ctx): # Defines a new "context" (ctx) command called "ping."
+        await ctx.send(f"Pong! ({bot.latency*1000}ms)")
+    
+    bot.run("your_bot_token_here")
 
 .. note::
     In this example we responded directly to the interaction, however if you want to delay the response (if you need more than 3 seconds before sending a message)


### PR DESCRIPTION
Updated quickstart.rst to use commands.Bot instead of discord.Client.

## About this pull request

Updated docs/quickstart.rst to use commands.Bot instead of discord.Client.

## Changes

Some changes were made to the example code blocks in the quickstart page of the docs to use commands.Bot instead of discord.Client to be consistent with the migration page.

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
