### PR TITLE
Capitalize booleans in gettingstarted.rst

### DIFF
--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -244,7 +244,7 @@ structure of how permissions are represented:
 +-------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------+
 | type        | int                                        | An `ApplicationCommandPermissionType`_.                                                             |
 +-------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------+
-| permission  | boolean                                    | ``true`` to allow, ``false`` to disallow.                                                           |
+| permission  | boolean                                    | ``True`` to allow, ``False`` to disallow.                                                           |
 +-------------+--------------------------------------------+-----------------------------------------------------------------------------------------------------+
 
 How the type parameter works is very simple. Discord has many ids to represent different things. As you can 


### PR DESCRIPTION
## About this pull request

Capitalize booleans in gettingstarted.rst

## Changes

The booleans in line 247 in the description column were all lowercase, but in Python they are supposed to be capitalized. I fixed that, and now they are capitalized instead of all lowercase.

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
