### PR TITLE
Fix #190 - exceptions on button interactions

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -887,6 +887,9 @@ class SlashCommand:
 
         to_use = msg["d"]
 
+        if to_use["type"] not in (1, 2):
+            return  # to only process ack and slash-commands and exclude other interactions like buttons
+
         if to_use["data"]["name"] in self.commands:
 
             ctx = context.SlashContext(self.req, to_use, self._discord, self.logger)


### PR DESCRIPTION
## About this pull request

Fix of issue with library trying and failing to process button interactions

## Changes

Added additional check to exclude interaction types other than 1 and 2 (ack and slash commands) in on_socket_response processing

## Checklist

- [X] I've checked this pull request runs on `Python 3.6.X`.
- [X] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #190 
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
