### PR TITLE
Add component support to SlashContext.send

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -130,7 +130,8 @@ class SlashContext:
                    files: typing.List[discord.File] = None,
                    allowed_mentions: discord.AllowedMentions = None,
                    hidden: bool = False,
-                   delete_after: float = None) -> model.SlashMessage:
+                   delete_after: float = None,
+                   components: typing.List[dict] = None) -> model.SlashMessage:
         """
         Sends response of the slash command.
 
@@ -157,6 +158,8 @@ class SlashContext:
         :type hidden: bool
         :param delete_after: If provided, the number of seconds to wait in the background before deleting the message we just sent. If the deletion fails, then it is silently ignored.
         :type delete_after: float
+        :param components: Message components in the response. The top level must be made of ActionRows.
+        :type components: List[dict]
         :return: Union[discord.Message, dict]
         """
         if embed and embeds:
@@ -180,7 +183,8 @@ class SlashContext:
             "tts": tts,
             "embeds": [x.to_dict() for x in embeds] if embeds else [],
             "allowed_mentions": allowed_mentions.to_dict() if allowed_mentions
-            else self.bot.allowed_mentions.to_dict() if self.bot.allowed_mentions else {}
+            else self.bot.allowed_mentions.to_dict() if self.bot.allowed_mentions else {},
+            "components": components if components else []
         }
         if hidden:
             base["flags"] = 64

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -177,6 +177,10 @@ class SlashContext:
             files = [file]
         if delete_after and hidden:
             raise error.IncorrectFormat("You can't delete a hidden message!")
+        if components:
+            for comp in components:
+                if comp.get("type") != 1:
+                    raise error.IncorrectFormat("The top level of the components list must be made of ActionRows!")
 
         base = {
             "content": content,

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -2,7 +2,8 @@ import typing
 import inspect
 import asyncio
 import aiohttp
-from ..error import RequestFailure, IncorrectType
+import discord
+from ..error import RequestFailure, IncorrectType, IncorrectFormat
 from ..model import SlashCommandOptionType, SlashCommandPermissionType
 from collections.abc import Callable
 from typing import Union
@@ -257,6 +258,51 @@ def create_option(name: str,
         "type": option_type,
         "required": required,
         "choices": choices
+    }
+
+
+def create_actionrow(components: typing.List[dict]) -> dict:
+    """
+    Creates an ActionRow for message components.
+
+    :param components: Components to go within the ActionRow.
+    :return: dict
+    """
+
+    return {
+        "type": 1,
+        "components": components
+    }
+
+
+def create_button(style: int,
+                  label: str = None,
+                  emoji: Union[discord.Emoji, dict] = None,
+                  custom_id: str = None,
+                  url: str = None,
+                  disabled: bool = False) -> dict:
+    if style == 5 and custom_id:
+        raise IncorrectFormat("A link button cannot have a `custom_id`!")
+    if style == 5 and not url:
+        raise IncorrectFormat("A link button must have a `url`!")
+    if not custom_id and style != 5:
+        raise IncorrectFormat("A non-link button must have a `custom_id`!")
+    if url and style != 5:
+        raise IncorrectFormat("You can't have a URL on a non-link button!")
+    if not label and not emoji:
+        raise IncorrectFormat("You must have at least a label or emoji on a button.")
+
+    if isinstance(emoji, discord.Emoji):
+        emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}
+
+    return {
+        "type": 2,
+        "style": style,
+        "label": label if label else "",
+        "emoji": emoji if emoji else {},
+        "custom_id": custom_id if custom_id else "",
+        "url": url if url else "",
+        "disabled": disabled
     }
 
 


### PR DESCRIPTION
## About this pull request
Adds component support for sending messages. It's set up to act similarly to the `options` parameter. This does **NOT** add support for handling button/component interactions, hence being a draft PR. Might be a bit rough around the edges at the moment.

## Changes
- Adds `components` parameter to `SlashContext.send`
- Adds `create_actionrow` and `create_button` to `discord_slash.utils.manage_commands`

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
