### PR TITLE
Fix manage commands

### DIFF
--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -147,7 +147,7 @@ async def get_all_guild_commands_permissions(bot_id,
                                              bot_token,
                                              guild_id):
     """
-    A coroutine that sends a slash command get request to Discord API.
+    A coroutine that sends a gets all the commands permissions for that guild.
 
     :param bot_id: User ID of the bot.
     :param bot_token: Token of the bot.
@@ -155,7 +155,7 @@ async def get_all_guild_commands_permissions(bot_id,
     :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#get-application-command-permissions>.
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
-    url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/permissions"
+    url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/permissions"
     async with aiohttp.ClientSession() as session:
         async with session.get(url, headers={"Authorization": f"Bot {bot_token}"}) as resp:
             if resp.status == 429:
@@ -165,7 +165,7 @@ async def get_all_guild_commands_permissions(bot_id,
             if not 200 <= resp.status < 300:
                 raise RequestFailure(resp.status, await resp.text())
             return await resp.json()
-
+          
 
 async def update_single_command_permissions(bot_id,
                                             bot_token,
@@ -173,7 +173,7 @@ async def update_single_command_permissions(bot_id,
                                             command_id,
                                             permissions):
     """
-    A coroutine that sends a slash command put request to Discord API.
+    A coroutine that sends a request to update a single command's permissions in guild
 
     :param bot_id: User ID of the bot.
     :param bot_token: Token of the bot.
@@ -189,10 +189,11 @@ async def update_single_command_permissions(bot_id,
             if resp.status == 429:
                 _json = await resp.json()
                 await asyncio.sleep(_json["retry_after"])
-                return await update_guild_commands_permissions(bot_id, bot_token, guild_id, permissions)
+                return await update_single_command_permissions(bot_id, bot_token, guild_id, permissions)
             if not 200 <= resp.status < 300:
                 raise RequestFailure(resp.status, await resp.text())
             return await resp.json()
+
 
 
 async def update_guild_commands_permissions(bot_id,
@@ -200,7 +201,7 @@ async def update_guild_commands_permissions(bot_id,
                                             guild_id,
                                             cmd_permissions):
     """
-    A coroutine that sends a slash command put request to Discord API.
+    A coroutine that updates permissions for all commands in a guild. 
 
     :param bot_id: User ID of the bot.
     :param bot_token: Token of the bot.
@@ -209,7 +210,7 @@ async def update_guild_commands_permissions(bot_id,
     :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#batch-edit-application-command-permissions>.
     :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
     """
-    url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/permissions"
+    url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/permissions"
     async with aiohttp.ClientSession() as session:
         async with session.put(url, headers={"Authorization": f"Bot {bot_token}"}, json=cmd_permissions) as resp:
             if resp.status == 429:

--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -166,6 +166,33 @@ async def get_all_guild_commands_permissions(bot_id,
                 raise RequestFailure(resp.status, await resp.text())
             return await resp.json()
           
+   async def get_guild_command_permissions(bot_id,
+                                            bot_token,
+                                            guild_id,
+                                            command_id):
+    """
+    A coroutine that sends a request to get a single command's permissions in guild
+
+    :param bot_id: User ID of the bot.
+    :param bot_token: Token of the bot.
+    :param guild_id: ID of the guild to update permissions on.
+    :param command_id: ID for the command to update permissions on.
+    :param permissions: List of permissions for the command.
+    :return: JSON Response of the request. A list of <https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions>
+    :raises: :class:`.error.RequestFailure` - Requesting to Discord API has failed.
+    """
+    url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/{command_id}/permissions"
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, headers={"Authorization": f"Bot {bot_token}"}) as resp:
+            if resp.status == 429:
+                _json = await resp.json()
+                await asyncio.sleep(_json["retry_after"])
+                return await get_guild_command_permissions(bot_id, bot_token, guild_id)
+            if not 200 <= resp.status < 300:
+                raise RequestFailure(resp.status, await resp.text())
+            return await resp.json()
+
+          
 
 async def update_single_command_permissions(bot_id,
                                             bot_token,


### PR DESCRIPTION
## About this pull request
This fixes bugs with the incorrect url path being used for some permissions functions in `manage_commands.py`
It also adds the missing `Get Application Command Permissions` to `manage_commands.py`
Updated the descriptions of some permissions functions

I suggest this be considered a priority along with #197 

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #198 
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
