### PR TITLE
Add components sending and handling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
     <br>
     <a href="https://pypi.org/project/discord-py-slash-command/"><img src="https://raw.githubusercontent.com/eunwoo1104/discord-py-slash-command/master/.github/discordpyslashlogo.png" alt="discord-py-slash-command" height="128"></a>
-    <h2 align = "center">A simple discord slash command handler for <a href="https://github.com/Rapptz/discord.py">discord.py</a></h2>
+    <h2 align = "center">A fork of a simple discord slash command handler for <a href="https://github.com/Rapptz/discord.py">discord.py</a> with support of discord components</h2>
 </p>
 <p align="center">
         <a href="https://app.codacy.com/gh/eunwoo1104/discord-py-slash-command?utm_source=github.com&utm_medium=referral&utm_content=eunwoo1104/discord-py-slash-command&utm_campaign=Badge_Grade_Settings"><img src="https://api.codacy.com/project/badge/Grade/224bdbe58f8f43f28a093a33a7546456" alt="Codacy Badge"></a>
@@ -24,9 +24,9 @@ code and substituting its own for where it's needed. *discord-py-slash-command* 
 slash command handler library to be made for Discord Bot API libraries.
 
 ## Installation
-You are able to easily install the *discord-py-slash-command* library by using the given PIP line below:
+You are able to easily install the *discord-py-interactions* library by using the given PIP line below:
 
-`pip install -U discord-py-slash-command`
+`pip install -U git+https://github.com/artem30801/discord-py-slash-command`
 
 ## Examples
 ### Quick Startup

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
    <a href="#about">About</a> ⦿
    <a href="#installation">Installation</a> ⦿
    <a href="#examples">Examples</a> ⦿
-   <a href="https://discord-py-slash-command.readthedocs.io/en/latest/">Documentation</a> ⦿
+   <a href="https://discord-py-interactions.readthedocs.io/en/latest/">Documentation on the fork</a> ⦿
    <a href="https://discord.gg/KkgMBVuEkx">Discord Server</a>
 </p>
    
@@ -24,9 +24,9 @@ code and substituting its own for where it's needed. *discord-py-slash-command* 
 slash command handler library to be made for Discord Bot API libraries.
 
 ## Installation
-You are able to easily install the *discord-py-interactions* library by using the given PIP line below:
+You are able to easily install this *discord-py-interactions* library fork by using the given PIP line below:
 
-`pip install -U git+https://github.com/artem30801/discord-py-slash-command`
+`pip install -U git+https://github.com/artem30801/discord-py-interactions`
 
 ## Examples
 ### Quick Startup

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
     <br>
     <a href="https://pypi.org/project/discord-py-slash-command/"><img src="https://raw.githubusercontent.com/eunwoo1104/discord-py-slash-command/master/.github/discordpyslashlogo.png" alt="discord-py-slash-command" height="128"></a>
-    <h2 align = "center">A fork of a simple discord slash command handler for <a href="https://github.com/Rapptz/discord.py">discord.py</a> with support of discord components</h2>
+    <h2 align = "center">A simple discord slash command handler for <a href="https://github.com/Rapptz/discord.py">discord.py</a></h2>
 </p>
 <p align="center">
         <a href="https://app.codacy.com/gh/eunwoo1104/discord-py-slash-command?utm_source=github.com&utm_medium=referral&utm_content=eunwoo1104/discord-py-slash-command&utm_campaign=Badge_Grade_Settings"><img src="https://api.codacy.com/project/badge/Grade/224bdbe58f8f43f28a093a33a7546456" alt="Codacy Badge"></a>
@@ -11,7 +11,7 @@
    <a href="#about">About</a> ⦿
    <a href="#installation">Installation</a> ⦿
    <a href="#examples">Examples</a> ⦿
-   <a href="https://discord-py-interactions.readthedocs.io/en/latest/">Documentation on the fork</a> ⦿
+   <a href="https://discord-py-slash-command.readthedocs.io/en/latest/">Documentation</a> ⦿
    <a href="https://discord.gg/KkgMBVuEkx">Discord Server</a>
 </p>
    
@@ -24,9 +24,9 @@ code and substituting its own for where it's needed. *discord-py-slash-command* 
 slash command handler library to be made for Discord Bot API libraries.
 
 ## Installation
-You are able to easily install this *discord-py-interactions* library fork by using the given PIP line below:
+You are able to easily install the *discord-py-slash-command* library by using the given PIP line below:
 
-`pip install -U git+https://github.com/artem30801/discord-py-interactions`
+`pip install -U discord-py-slash-command`
 
 ## Examples
 ### Quick Startup

--- a/discord_slash/__init__.py
+++ b/discord_slash/__init__.py
@@ -12,5 +12,6 @@ from .client import SlashCommand
 from .model import SlashCommandOptionType
 from .context import SlashContext
 from .utils import manage_commands
+from .utils import manage_components
 
 __version__ = "1.2.0"

--- a/discord_slash/__init__.py
+++ b/discord_slash/__init__.py
@@ -14,4 +14,4 @@ from .context import SlashContext
 from .utils import manage_commands
 from .utils import manage_components
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"

--- a/discord_slash/__init__.py
+++ b/discord_slash/__init__.py
@@ -11,6 +11,8 @@ Simple Discord Slash Command extension for discord.py
 from .client import SlashCommand
 from .model import SlashCommandOptionType
 from .context import SlashContext
+from .context import ComponentContext
+from .dpy_overrides import ComponentMessage
 from .utils import manage_commands
 from .utils import manage_components
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -870,7 +870,10 @@ class SlashCommand:
         :param args: Args. Can be list or dict.
         """
         try:
-            await func.invoke(ctx, args)
+            if isinstance(args, dict):
+                await func.invoke(ctx, **args)
+            else:
+                await func.invoke(ctx, *args)
         except Exception as ex:
             await self.on_slash_command_error(ctx, ex)
 

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -875,6 +875,13 @@ class SlashCommand:
             else:
                 await func.invoke(ctx, *args)
         except Exception as ex:
+            if hasattr(func, "on_error"):
+                if func.on_error is not None:
+                    try:
+                        await func.on_error(ctx, ex)
+                        return
+                    except Exception as e:
+                        self.logger.error(f"{ctx.command}:: Error using error decorator: {e}")
             await self.on_slash_command_error(ctx, ex)
 
     async def on_socket_response(self, msg):

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -878,7 +878,10 @@ class SlashCommand:
             if hasattr(func, "on_error"):
                 if func.on_error is not None:
                     try:
-                        await func.on_error(ctx, ex)
+                        if hasattr(func, "cog"):
+                            await func.on_error(func.cog, ctx, ex)
+                        else:
+                            await func.on_error(ctx, ex)
                         return
                     except Exception as e:
                         self.logger.error(f"{ctx.command}:: Error using error decorator: {e}")

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -1,3 +1,4 @@
+import datetime
 import typing
 import asyncio
 from warnings import warn
@@ -5,6 +6,8 @@ from warnings import warn
 import discord
 from contextlib import suppress
 from discord.ext import commands
+from discord.utils import snowflake_time
+
 from . import http
 from . import error
 from . import model
@@ -56,6 +59,7 @@ class InteractionContext:
             self.author = discord.User(data=_json["member"]["user"], state=self.bot._connection)
         else:
             self.author = discord.User(data=_json["user"], state=self.bot._connection)
+        self.created_at: datetime.datetime = snowflake_time(int(self.interaction_id))
 
     @property
     def _deffered_hidden(self):

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -259,7 +259,7 @@ class ComponentContext(InteractionContext):
         self.origin_message = None
         self.origin_message_id = int(_json["message"]["id"]) if "message" in _json.keys() else None
 
-        if self.origin_message_id:
+        if self.origin_message_id and (_json["message"]["flags"] & 64) != 64:
             self.origin_message = ComponentMessage(state=self.bot._connection, channel=self.channel,
                                                    data=_json["message"])
 

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -350,5 +350,6 @@ class ComponentContext(InteractionContext):
             for file in files:
                 file.close()
 
-        self.origin_message = ComponentMessage(state=self.bot._connection, channel=self.channel,
-                                               data=_json["message"])
+        # Commented out for now as sometimes (or at least, when not deferred) _json is an empty string?
+        # self.origin_message = ComponentMessage(state=self.bot._connection, channel=self.channel,
+        #                                        data=_json)

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -227,7 +227,7 @@ class InteractionContext:
 
 class SlashContext(InteractionContext):
     """
-    Context of a slash command. Has all variables from :class:`InteractionContext`, plus the slash-command-specific ones below.
+    Context of a slash command. Has all attributes from :class:`InteractionContext`, plus the slash-command-specific ones below.
 
     :ivar name: Name of the command.
     :ivar args: List of processed arguments invoked with the command.
@@ -253,7 +253,7 @@ class SlashContext(InteractionContext):
 
 class ComponentContext(InteractionContext):
     """
-    Context of a component interaction. Has all variables from :class:`InteractionContext`, plus the component-specific ones below.
+    Context of a component interaction. Has all attributes from :class:`InteractionContext`, plus the component-specific ones below.
 
     :ivar custom_id: The custom ID of the component.
     :ivar component_type: The type of the component.
@@ -275,12 +275,12 @@ class ComponentContext(InteractionContext):
             self.origin_message = ComponentMessage(state=self.bot._connection, channel=self.channel,
                                                    data=_json["message"])
 
-    async def defer(self, hidden: bool = False, edit_origin = False):
+    async def defer(self, hidden: bool = False, edit_origin: bool = False):
         """
         'Defers' the response, showing a loading state to the user
 
         :param hidden: Whether the deferred response should be ephemeral . Default ``False``.
-        :param edit_origin: Whether the response is editting the origin message. If ``False``, the deferred response will be for a follow up message. Defaults ``False``.
+        :param edit_origin: Whether the response is editing the origin message. If ``False``, the deferred response will be for a follow up message. Defaults ``False``.
         """
         if self.deferred or self.responded:
             raise error.AlreadyResponded("You have already responded to this command!")

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -258,7 +258,7 @@ class ComponentContext(InteractionContext):
     :ivar custom_id: The custom ID of the component.
     :ivar component_type: The type of the component.
     :ivar origin_message: The origin message of the component. Not available if the origin message was ephemeral.
-    :ivar origin_message_id: The ID of the origin message. Not available if the origin message was ephemeral.
+    :ivar origin_message_id: The ID of the origin message.
     """
     def __init__(self,
                  _http: http.SlashCommandRequest,

--- a/discord_slash/dpy_overrides.py
+++ b/discord_slash/dpy_overrides.py
@@ -1,0 +1,254 @@
+import discord
+from discord.ext import commands
+from discord import AllowedMentions, InvalidArgument, File
+from discord.http import Route
+from discord import http
+from discord import abc
+from discord import utils
+
+
+class ComponentMessage(discord.Message):
+    __slots__ = tuple(list(discord.Message.__slots__) + ["components"])
+
+    def __init__(self, *, state, channel, data):
+        super().__init__(state=state, channel=channel, data=data)
+        self.components = data['components']
+
+
+def new_override(cls, *args, **kwargs):
+    if cls is discord.Message:
+        return object.__new__(ComponentMessage)
+    else:
+        return object.__new__(cls)
+
+
+discord.message.Message.__new__ = new_override
+
+
+def send_files(self, channel_id, *, files, content=None, tts=False, embed=None, components=None,
+               nonce=None, allowed_mentions=None, message_reference=None):
+    r = Route('POST', '/channels/{channel_id}/messages', channel_id=channel_id)
+    form = []
+
+    payload = {'tts': tts}
+    if content:
+        payload['content'] = content
+    if embed:
+        payload['embed'] = embed
+    if components:
+        payload['components'] = components
+    if nonce:
+        payload['nonce'] = nonce
+    if allowed_mentions:
+        payload['allowed_mentions'] = allowed_mentions
+    if message_reference:
+        payload['message_reference'] = message_reference
+
+    form.append({'name': 'payload_json', 'value': utils.to_json(payload)})
+    if len(files) == 1:
+        file = files[0]
+        form.append({
+            'name': 'file',
+            'value': file.fp,
+            'filename': file.filename,
+            'content_type': 'application/octet-stream'
+        })
+    else:
+        for index, file in enumerate(files):
+            form.append({
+                'name': 'file%s' % index,
+                'value': file.fp,
+                'filename': file.filename,
+                'content_type': 'application/octet-stream'
+            })
+
+    return self.request(r, form=form, files=files)
+
+
+def send_message(self, channel_id, content, *, tts=False, embed=None, components=None,
+                 nonce=None, allowed_mentions=None, message_reference=None):
+    r = Route('POST', '/channels/{channel_id}/messages', channel_id=channel_id)
+    payload = {}
+
+    if content:
+        payload['content'] = content
+
+    if tts:
+        payload['tts'] = True
+
+    if embed:
+        payload['embed'] = embed
+
+    if components:
+        payload['components'] = components
+
+    if nonce:
+        payload['nonce'] = nonce
+
+    if allowed_mentions:
+        payload['allowed_mentions'] = allowed_mentions
+
+    if message_reference:
+        payload['message_reference'] = message_reference
+
+    return self.request(r, json=payload)
+
+
+http.HTTPClient.send_files = send_files
+http.HTTPClient.send_message = send_message
+
+
+async def send(self, content=None, *, tts=False, embed=None, file=None, components=None,
+               files=None, delete_after=None, nonce=None,
+               allowed_mentions=None, reference=None,
+               mention_author=None):
+    """|coro|
+
+    Sends a message to the destination with the content given.
+
+    The content must be a type that can convert to a string through ``str(content)``.
+    If the content is set to ``None`` (the default), then the ``embed`` parameter must
+    be provided.
+
+    To upload a single file, the ``file`` parameter should be used with a
+    single :class:`~discord.File` object. To upload multiple files, the ``files``
+    parameter should be used with a :class:`list` of :class:`~discord.File` objects.
+    **Specifying both parameters will lead to an exception**.
+
+    If the ``embed`` parameter is provided, it must be of type :class:`~discord.Embed` and
+    it must be a rich embed type.
+
+    Parameters
+    ------------
+    content: :class:`str`
+        The content of the message to send.
+    tts: :class:`bool`
+        Indicates if the message should be sent using text-to-speech.
+    embed: :class:`~discord.Embed`
+        The rich embed for the content.
+    file: :class:`~discord.File`
+        The file to upload.
+    files: List[:class:`~discord.File`]
+        A list of files to upload. Must be a maximum of 10.
+    nonce: :class:`int`
+        The nonce to use for sending this message. If the message was successfully sent,
+        then the message will have a nonce with this value.
+    delete_after: :class:`float`
+        If provided, the number of seconds to wait in the background
+        before deleting the message we just sent. If the deletion fails,
+        then it is silently ignored.
+    allowed_mentions: :class:`~discord.AllowedMentions`
+        Controls the mentions being processed in this message. If this is
+        passed, then the object is merged with :attr:`~discord.Client.allowed_mentions`.
+        The merging behaviour only overrides attributes that have been explicitly passed
+        to the object, otherwise it uses the attributes set in :attr:`~discord.Client.allowed_mentions`.
+        If no object is passed at all then the defaults given by :attr:`~discord.Client.allowed_mentions`
+        are used instead.
+
+        .. versionadded:: 1.4
+
+    reference: Union[:class:`~discord.Message`, :class:`~discord.MessageReference`]
+        A reference to the :class:`~discord.Message` to which you are replying, this can be created using
+        :meth:`~discord.Message.to_reference` or passed directly as a :class:`~discord.Message`. You can control
+        whether this mentions the author of the referenced message using the :attr:`~discord.AllowedMentions.replied_user`
+        attribute of ``allowed_mentions`` or by setting ``mention_author``.
+
+        .. versionadded:: 1.6
+
+    mention_author: Optional[:class:`bool`]
+        If set, overrides the :attr:`~discord.AllowedMentions.replied_user` attribute of ``allowed_mentions``.
+
+        .. versionadded:: 1.6
+
+    Raises
+    --------
+    ~discord.HTTPException
+        Sending the message failed.
+    ~discord.Forbidden
+        You do not have the proper permissions to send the message.
+    ~discord.InvalidArgument
+        The ``files`` list is not of the appropriate size,
+        you specified both ``file`` and ``files``,
+        or the ``reference`` object is not a :class:`~discord.Message`
+        or :class:`~discord.MessageReference`.
+
+    Returns
+    ---------
+    :class:`~discord.Message`
+        The message that was sent.
+    """
+
+    channel = await self._get_channel()
+    state = self._state
+    content = str(content) if content is not None else None
+    components = components or []
+    if embed is not None:
+        embed = embed.to_dict()
+
+    if allowed_mentions is not None:
+        if state.allowed_mentions is not None:
+            allowed_mentions = state.allowed_mentions.merge(allowed_mentions).to_dict()
+        else:
+            allowed_mentions = allowed_mentions.to_dict()
+    else:
+        allowed_mentions = state.allowed_mentions and state.allowed_mentions.to_dict()
+
+    if mention_author is not None:
+        allowed_mentions = allowed_mentions or AllowedMentions().to_dict()
+        allowed_mentions['replied_user'] = bool(mention_author)
+
+    if reference is not None:
+        try:
+            reference = reference.to_message_reference_dict()
+        except AttributeError:
+            raise InvalidArgument('reference parameter must be Message or MessageReference') from None
+
+    if file is not None and files is not None:
+        raise InvalidArgument('cannot pass both file and files parameter to send()')
+
+    if file is not None:
+        if not isinstance(file, File):
+            raise InvalidArgument('file parameter must be File')
+
+        try:
+            data = await state.http.send_files(channel.id, files=[file], allowed_mentions=allowed_mentions,
+                                               content=content, tts=tts, embed=embed, nonce=nonce,
+                                               components=components,
+                                               message_reference=reference)
+        finally:
+            file.close()
+
+    elif files is not None:
+        if len(files) > 10:
+            raise InvalidArgument('files parameter must be a list of up to 10 elements')
+        elif not all(isinstance(file, File) for file in files):
+            raise InvalidArgument('files parameter must be a list of File')
+
+        try:
+            data = await state.http.send_files(channel.id, files=files, content=content, tts=tts,
+                                               embed=embed, nonce=nonce, allowed_mentions=allowed_mentions,
+                                               components=components,
+                                               message_reference=reference)
+        finally:
+            for f in files:
+                f.close()
+    else:
+        data = await state.http.send_message(channel.id, content, tts=tts, embed=embed, components=components,
+                                             nonce=nonce, allowed_mentions=allowed_mentions,
+                                             message_reference=reference)
+
+    ret = state.create_message(channel=channel, data=data)
+    if delete_after is not None:
+        await ret.delete(delay=delete_after)
+    return ret
+
+
+async def send_override(context_or_channel, *args, **kwargs):
+    if isinstance(context_or_channel, commands.Context):
+        channel = context_or_channel.channel
+    else:
+        channel = context_or_channel
+
+    return await send(channel, *args, **kwargs)
+
+abc.Messageable.send = send_override

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -5,6 +5,7 @@ from contextlib import suppress
 from inspect import iscoroutinefunction
 from . import http
 from . import error
+from . dpy_overrides import ComponentMessage
 
 
 class ChoiceData:
@@ -365,7 +366,7 @@ class SlashCommandOptionType(IntEnum):
         if issubclass(t, discord.abc.Role): return cls.ROLE
 
 
-class SlashMessage(discord.Message):
+class SlashMessage(ComponentMessage):
     """discord.py's :class:`discord.Message` but overridden ``edit`` and ``delete`` to work for slash command."""
 
     def __init__(self, *, state, channel, data, _http: http.SlashCommandRequest, interaction_token):
@@ -388,6 +389,10 @@ class SlashMessage(discord.Message):
         embeds = fields.get("embeds")
         file = fields.get("file")
         files = fields.get("files")
+        components = fields.get("components")
+
+        if components:
+            _resp["components"] = components
 
         if embed and embeds:
             raise error.IncorrectFormat("You can't use both `embed` and `embeds`!")

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -1,8 +1,13 @@
 import asyncio
+import datetime
+
 import discord
 from enum import IntEnum
 from contextlib import suppress
 from inspect import iscoroutinefunction
+
+from discord.ext.commands import CooldownMapping, CommandOnCooldown
+
 from . import http
 from . import error
 from . dpy_overrides import ComponentMessage
@@ -132,38 +137,111 @@ class CommandObject:
         if hasattr(self.func, '__commands_checks__'):
             self.__commands_checks__ = self.func.__commands_checks__
 
-    async def invoke(self, *args):
+        cooldown = None
+        if hasattr(self.func, "__commands_cooldown__"):
+            cooldown = self.func.__commands_cooldown__
+        self._buckets = CooldownMapping(cooldown)
+
+        self._max_concurrency = None
+        if hasattr(self.func, "__commands_max_concurrency__"):
+            self._max_concurrency = self.func.__commands_max_concurrency__
+
+    def _prepare_cooldowns(self, ctx):
+        """
+        Ref https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/core.py#L765
+        """
+        if self._buckets.valid:
+            dt = ctx.created_at
+            current = dt.replace(tzinfo=datetime.timezone.utc).timestamp()
+            bucket = self._buckets.get_bucket(ctx, current)
+            retry_after = bucket.update_rate_limit(current)
+            if retry_after:
+                raise CommandOnCooldown(bucket, retry_after)
+
+    async def _concurrency_checks(self, ctx):
+        """The checks required for cooldown and max concurrency."""
+        # max concurrency checks
+        if self._max_concurrency is not None:
+            await self._max_concurrency.acquire(ctx)
+        try:
+            # cooldown checks
+            self._prepare_cooldowns(ctx)
+        except:
+            if self._max_concurrency is not None:
+                await self._max_concurrency.release(ctx)
+            raise
+
+    async def invoke(self, *args, **kwargs):
         """
         Invokes the command.
 
         :param args: Args for the command.
         :raises: .error.CheckFailure
         """
-        args = list(args)
-        ctx = args.pop(0)
-        can_run = await self.can_run(ctx)
+        can_run = await self.can_run(args[0])
         if not can_run:
             raise error.CheckFailure
 
-        coro = None  # Get rid of annoying IDE complainings.
+        await self._concurrency_checks(args[0])
 
-        not_kwargs = False
-        if args and isinstance(args[0], dict):
-            kwargs = args[0]
-            ctx.kwargs = kwargs
-            ctx.args = list(kwargs.values())
-            try:
-                coro = self.func(ctx, **kwargs)
-            except TypeError:
-                args = list(kwargs.values())
-                not_kwargs = True
-        else:
-            ctx.args = args
-            not_kwargs = True
-        if not_kwargs:
-            coro = self.func(ctx, *args)
+        # to preventing needing different functions per object,
+        # this function simply handles cogs
+        if hasattr(self, "cog"):
+            return await self.func(self.cog, *args, **kwargs)
+        return await self.func(*args, **kwargs)
 
-        return await coro
+    def is_on_cooldown(self, ctx):
+        """Checks whether the command is currently on cooldown.
+        Ref https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/core.py#L797
+        Parameters
+        -----------
+        ctx: :class:`.Context`
+            The invocation context to use when checking the commands cooldown status.
+        Returns
+        --------
+        :class:`bool`
+            A boolean indicating if the command is on cooldown.
+        """
+        if not self._buckets.valid:
+            return False
+
+        bucket = self._buckets.get_bucket(ctx.message)
+        dt = ctx.message.edited_at or ctx.message.created_at
+        current = dt.replace(tzinfo=datetime.timezone.utc).timestamp()
+        return bucket.get_tokens(current) == 0
+
+    def reset_cooldown(self, ctx):
+        """Resets the cooldown on this command.
+        Ref https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/core.py#L818
+        Parameters
+        -----------
+        ctx: :class:`.Context`
+            The invocation context to reset the cooldown under.
+        """
+        if self._buckets.valid:
+            bucket = self._buckets.get_bucket(ctx.message)
+            bucket.reset()
+
+    def get_cooldown_retry_after(self, ctx):
+        """Retrieves the amount of seconds before this command can be tried again.
+        Ref https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/core.py#L830
+        Parameters
+        -----------
+        ctx: :class:`.Context`
+            The invocation context to retrieve the cooldown from.
+        Returns
+        --------
+        :class:`float`
+            The amount of time left on this command's cooldown in seconds.
+            If this is ``0.0`` then the command isn't on cooldown.
+        """
+        if self._buckets.valid:
+            bucket = self._buckets.get_bucket(ctx.message)
+            dt = ctx.message.edited_at or ctx.message.created_at
+            current = dt.replace(tzinfo=datetime.timezone.utc).timestamp()
+            return bucket.get_retry_after(current)
+
+        return 0.0
 
     def add_check(self, func):
         """
@@ -255,39 +333,6 @@ class CogBaseCommandObject(BaseCommandObject):
         super().__init__(*args)
         self.cog = None  # Manually set this later.
 
-    async def invoke(self, *args, **kwargs):
-        """
-        Invokes the command.
-
-        :param args: Args for the command.
-        :raises: .error.CheckFailure
-        """
-        args = list(args)
-        ctx = args.pop(0)
-        can_run = await self.can_run(ctx)
-        if not can_run:
-            raise error.CheckFailure
-
-        coro = None  # Get rid of annoying IDE complainings.
-
-        not_kwargs = False
-        if args and isinstance(args[0], dict):
-            kwargs = args[0]
-            ctx.kwargs = kwargs
-            ctx.args = list(kwargs.values())
-            try:
-                coro = self.func(self.cog, ctx, **kwargs)
-            except TypeError:
-                args = list(kwargs.values())
-                not_kwargs = True
-        else:
-            ctx.args = args
-            not_kwargs = True
-        if not_kwargs:
-            coro = self.func(self.cog, ctx, *args)
-
-        return await coro
-
 
 class CogSubcommandObject(SubcommandObject):
     """
@@ -301,39 +346,6 @@ class CogSubcommandObject(SubcommandObject):
         super().__init__(sub, base, name, sub_group)
         self.base_command_data = cmd
         self.cog = None  # Manually set this later.
-
-    async def invoke(self, *args, **kwargs):
-        """
-        Invokes the command.
-
-        :param args: Args for the command.
-        :raises: .error.CheckFailure
-        """
-        args = list(args)
-        ctx = args.pop(0)
-        can_run = await self.can_run(ctx)
-        if not can_run:
-            raise error.CheckFailure
-
-        coro = None  # Get rid of annoying IDE complainings.
-
-        not_kwargs = False
-        if args and isinstance(args[0], dict):
-            kwargs = args[0]
-            ctx.kwargs = kwargs
-            ctx.args = list(kwargs.values())
-            try:
-                coro = self.func(self.cog, ctx, **kwargs)
-            except TypeError:
-                args = list(kwargs.values())
-                not_kwargs = True
-        else:
-            ctx.args = args
-            not_kwargs = True
-        if not_kwargs:
-            coro = self.func(self.cog, ctx, *args)
-
-        return await coro
 
 
 class SlashCommandOptionType(IntEnum):

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -146,6 +146,14 @@ class CommandObject:
         if hasattr(self.func, "__commands_max_concurrency__"):
             self._max_concurrency = self.func.__commands_max_concurrency__
 
+        self.on_error = None
+
+    def error(self, coro):
+        if not asyncio.iscoroutinefunction(coro):
+            raise TypeError("The error handler must be a coroutine.")
+        self.on_error = coro
+        return coro
+
     def _prepare_cooldowns(self, ctx):
         """
         Ref https://github.com/Rapptz/discord.py/blob/master/discord/ext/commands/core.py#L765
@@ -295,7 +303,6 @@ class BaseCommandObject(CommandObject):
         self.has_subcommands = cmd["has_subcommands"]
         self.default_permission = cmd["default_permission"]
         self.permissions = cmd["api_permissions"] or {}
-
 
 class SubcommandObject(CommandObject):
     """

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -159,12 +159,15 @@ def create_select(options: list[dict], custom_id=None, placeholder=None, min_val
     }
 
 
-async def wait_for_component(client, component, check=None, timeout=None) -> ComponentContext:
+async def wait_for_component(client: discord.Client, component: typing.Union[dict, str], check=None, timeout=None) \
+        -> ComponentContext:
     """
     Waits for a component interaction. Only accepts interactions based on the custom ID of the component, and optionally a check function.
 
     :param client: The client/bot object.
-    :param component: The component dict.
+    :type client: :class:`discord.Client`
+    :param component: The component dict or custom ID.
+    :type component: Union[dict, str]
     :param check: Optional check function. Must take a `ComponentContext` as the first parameter.
     :param timeout: The number of seconds to wait before timing out and raising :exc:`asyncio.TimeoutError`.
     :raises: :exc:`asyncio.TimeoutError`
@@ -172,17 +175,20 @@ async def wait_for_component(client, component, check=None, timeout=None) -> Com
     def _check(ctx):
         if check and not check(ctx):
             return False
-        return component["custom_id"] == ctx.custom_id
+        return (component["custom_id"] if isinstance(component, dict) else component) == ctx.custom_id
 
     return await client.wait_for("component", check=_check, timeout=timeout)
 
 
-async def wait_for_any_component(client, message, check=None, timeout=None) -> ComponentContext:
+async def wait_for_any_component(client: discord.Client, message: typing.Union[discord.Message, int],
+                                 check=None, timeout=None) -> ComponentContext:
     """
     Waits for any component interaction. Only accepts interactions based on the message ID given and optionally a check function.
 
     :param client: The client/bot object.
-    :param message: The message object to check for.
+    :type client: :class:`discord.Client`
+    :param message: The message object to check for, or the message ID.
+    :type message: Union[discord.Message, int]
     :param check: Optional check function. Must take a `ComponentContext` as the first parameter.
     :param timeout: The number of seconds to wait before timing out and raising :exc:`asyncio.TimeoutError`.
     :raises: :exc:`asyncio.TimeoutError`
@@ -190,7 +196,6 @@ async def wait_for_any_component(client, message, check=None, timeout=None) -> C
     def _check(ctx):
         if check and not check(ctx):
             return False
-        return message.id == ctx.origin_message_id
+        return (message.id if isinstance(message, discord.Message) else message) == ctx.origin_message_id
 
     return await client.wait_for("component", check=_check, timeout=timeout)
-

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -51,6 +51,8 @@ def create_button(style: int,
 
     if isinstance(emoji, discord.Emoji):
         emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}
+    elif isinstance(emoji, str):
+        emoji = {"name": emoji, "id": None}
 
     return {
         "type": ComponentsType.button,

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -47,7 +47,7 @@ def create_button(style: int,
     if not label and not emoji:
         raise IncorrectFormat("You must have at least a label or emoji on a button.")
     if not custom_id and style != 5:
-        custom_id = uuid.uuid4().int
+        custom_id = str(uuid.uuid4())
 
     if isinstance(emoji, discord.Emoji):
         emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -139,7 +139,7 @@ def create_select_option(label: str, value: str, emoji=None, description: str = 
     }
 
 
-def create_select(options: list[dict], custom_id=None, placeholder=None, min_values=None, max_values=None):
+def create_select(options: typing.List[dict], custom_id=None, placeholder=None, min_values=None, max_values=None):
     """
     Creates a select (dropdown) component for use with the ``components`` field. Must be inside an ActionRow to be used (see :meth:`create_actionrow`).
 

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -1,0 +1,82 @@
+import uuid
+import enum
+import typing
+import discord
+from ..error import IncorrectFormat
+
+
+class ComponentsType(enum.IntEnum):
+    actionrow = 1
+    button = 2
+
+
+def create_actionrow(*components: dict) -> dict:
+    """
+    Creates an ActionRow for message components.
+    :param components: Components to go within the ActionRow.
+    :return: dict
+    """
+
+    return {
+        "type": ComponentsType.actionrow,
+        "components": components
+    }
+
+
+class ButtonStyle(enum.IntEnum):
+    blue = 1
+    gray = 2
+    grey = 2
+    green = 3
+    red = 4
+    URL = 5
+
+
+def create_button(style: int,
+                  label: str = None,
+                  emoji: typing.Union[discord.Emoji, dict] = None,
+                  custom_id: str = None,
+                  url: str = None,
+                  disabled: bool = False) -> dict:
+    if style == 5 and custom_id:
+        raise IncorrectFormat("A link button cannot have a `custom_id`!")
+    if style == 5 and not url:
+        raise IncorrectFormat("A link button must have a `url`!")
+    if url and style != 5:
+        raise IncorrectFormat("You can't have a URL on a non-link button!")
+    if not label and not emoji:
+        raise IncorrectFormat("You must have at least a label or emoji on a button.")
+    if not custom_id and style != 5:
+        custom_id = uuid.uuid4().int
+
+    if isinstance(emoji, discord.Emoji):
+        emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}
+
+    return {
+        "type": ComponentsType.button,
+        "style": style,
+        "label": label if label else "",
+        "emoji": emoji if emoji else {},
+        "custom_id": custom_id if custom_id else "",
+        "url": url if url else "",
+        "disabled": disabled
+    }
+
+
+async def wait_for_component(client, component, check=None, timeout=None):
+    def _check(ctx):
+        if check and not check(ctx):
+            return False
+        return component["custom_id"] == ctx.custom_id
+
+    return await client.wait_for("component", check=_check, timeout=timeout)
+
+
+async def wait_for_any_component(client, message, check=None, timeout=None):
+    def _check(ctx):
+        if check and not check(ctx):
+            return False
+        return message.id == ctx.custom_id
+
+    return await client.wait_for("component", check=_check, timeout=timeout)
+

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -78,7 +78,7 @@ async def wait_for_any_component(client, message, check=None, timeout=None):
     def _check(ctx):
         if check and not check(ctx):
             return False
-        return message.id == ctx.custom_id
+        return message.id == ctx.origin_message_id
 
     return await client.wait_for("component", check=_check, timeout=timeout)
 

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -8,6 +8,7 @@ from ..error import IncorrectFormat
 class ComponentsType(enum.IntEnum):
     actionrow = 1
     button = 2
+    select = 3
 
 
 def create_actionrow(*components: dict) -> dict:
@@ -32,6 +33,14 @@ class ButtonStyle(enum.IntEnum):
     URL = 5
 
 
+def emoji_to_dict(emoji):
+    if isinstance(emoji, discord.Emoji):
+        emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}
+    elif isinstance(emoji, str):
+        emoji = {"name": emoji, "id": None}
+    return emoji if emoji else {}
+
+
 def create_button(style: int,
                   label: str = None,
                   emoji: typing.Union[discord.Emoji, dict] = None,
@@ -49,19 +58,42 @@ def create_button(style: int,
     if not custom_id and style != 5:
         custom_id = str(uuid.uuid4())
 
-    if isinstance(emoji, discord.Emoji):
-        emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}
-    elif isinstance(emoji, str):
-        emoji = {"name": emoji, "id": None}
+    emoji = emoji_to_dict(emoji)
 
     return {
         "type": ComponentsType.button,
         "style": style,
         "label": label if label else "",
-        "emoji": emoji if emoji else {},
-        "custom_id": custom_id if custom_id else "",
+        "emoji": emoji,
+        "custom_id": custom_id,
         "url": url if url else "",
         "disabled": disabled
+    }
+
+
+def create_select_option(label: str, value: str, emoji=None, description: str = None, default=False):
+    emoji = emoji_to_dict(emoji)
+
+    return {
+        "label": label,
+        "value": value,
+        "description": description,
+        "default": default,
+        "emoji": emoji
+    }
+
+
+def create_select(options: list[dict], custom_id=None, placeholder=None, min_values=None, max_values=None):
+    if not len(options) or len(options) > 25:
+        raise IncorrectFormat("Options length should be between 1 and 25.")
+
+    return {
+        "type": ComponentsType.select,
+        "options": options,
+        "custom_id": custom_id or str(uuid.uuid4()),
+        "placeholder": placeholder or "",
+        "min_values": min_values,
+        "max_values": max_values,
     }
 
 

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -15,11 +15,12 @@ class ComponentsType(enum.IntEnum):
 def create_actionrow(*components: dict) -> dict:
     """
     Creates an ActionRow for message components.
+
     :param components: Components to go within the ActionRow.
     :return: dict
     """
     if not components or len(components) > 5:
-        raise IncorrectFormat("Number of components in one row should be between 1 and 25.")
+        raise IncorrectFormat("Number of components in one row should be between 1 and 5.")
     if ComponentsType.select in [component["type"] for component in components] and len(components) > 1:
         raise IncorrectFormat("Action row must have only one select component and nothing else")
 
@@ -44,7 +45,13 @@ class ButtonStyle(enum.IntEnum):
     danger = 4
 
 
-def emoji_to_dict(emoji):
+def emoji_to_dict(emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str]) -> dict:
+    """
+    Converts a default or custom emoji into a partial emoji dict.
+
+    :param emoji: The emoji to convert.
+    :type emoji: Union[discord.Emoji, discord.PartialEmoji, str]
+    """
     if isinstance(emoji, discord.Emoji):
         emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}
     elif isinstance(emoji, str):
@@ -52,12 +59,32 @@ def emoji_to_dict(emoji):
     return emoji if emoji else {}
 
 
-def create_button(style: ButtonStyle,
+def create_button(style: typing.Union[ButtonStyle, int],
                   label: str = None,
-                  emoji: typing.Union[discord.Emoji, dict] = None,
+                  emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str] = None,
                   custom_id: str = None,
                   url: str = None,
                   disabled: bool = False) -> dict:
+    """
+    Creates a button component for use with the ``components`` field. Must be inside an ActionRow to be used (see :meth:`create_actionrow`).
+
+    .. note::
+        At least a label or emoji is required for a button. You can have both, but not neither of them.
+
+    :param style: Style of the button. Refer to :class:`ButtonStyle`.
+    :type style: Union[ButtonStyle, int]
+    :param label: The label of the button.
+    :type label: Optional[str]
+    :param emoji: The emoji of the button.
+    :type emoji: Union[discord.Emoji, discord.PartialEmoji, dict]
+    :param custom_id: The custom_id of the button. Needed for non-link buttons.
+    :type custom_id: Optional[str]
+    :param url: The URL of the button. Needed for link buttons.
+    :type url: Optional[str]
+    :param disabled: Whether the button is disabled or not. Defaults to `False`.
+    :type disabled: bool
+    :returns: :class:`dict`
+    """
     if style == ButtonStyle.URL:
         if custom_id:
             raise IncorrectFormat("A link button cannot have a `custom_id`!")
@@ -91,7 +118,16 @@ def create_button(style: ButtonStyle,
     return data
 
 
-def create_select_option(label: str, value: str, emoji=None, description: str = None, default=False):
+def create_select_option(label: str, value: str, emoji=None, description: str = None, default: bool = False):
+    """
+    Creates an option for select components.
+
+    :param label: The label of the option.
+    :param value: The value that the bot will recieve when this option is selected.
+    :param emoji: The emoji of the option.
+    :param description: A description of the option.
+    :param default: Whether or not this is the default option.
+    """
     emoji = emoji_to_dict(emoji)
 
     return {
@@ -104,6 +140,12 @@ def create_select_option(label: str, value: str, emoji=None, description: str = 
 
 
 def create_select(options: list[dict], custom_id=None, placeholder=None, min_values=None, max_values=None):
+    """
+    Creates a select (dropdown) component for use with the ``components`` field. Must be inside an ActionRow to be used (see :meth:`create_actionrow`).
+
+    .. warning::
+        Currently, select components are not available for public use, nor have official documentation. The parameters will not be documented at this time.
+    """
     if not len(options) or len(options) > 25:
         raise IncorrectFormat("Options length should be between 1 and 25.")
 
@@ -118,6 +160,15 @@ def create_select(options: list[dict], custom_id=None, placeholder=None, min_val
 
 
 async def wait_for_component(client, component, check=None, timeout=None) -> ComponentContext:
+    """
+    Waits for a component interaction. Only accepts interactions based on the custom ID of the component, and optionally a check function.
+
+    :param client: The client/bot object.
+    :param component: The component dict.
+    :param check: Optional check function. Must take a `ComponentContext` as the first parameter.
+    :param timeout: The number of seconds to wait before timing out and raising :exc:`asyncio.TimeoutError`.
+    :raises: :exc:`asyncio.TimeoutError`
+    """
     def _check(ctx):
         if check and not check(ctx):
             return False
@@ -127,6 +178,15 @@ async def wait_for_component(client, component, check=None, timeout=None) -> Com
 
 
 async def wait_for_any_component(client, message, check=None, timeout=None) -> ComponentContext:
+    """
+    Waits for any component interaction. Only accepts interactions based on the message ID given and optionally a check function.
+
+    :param client: The client/bot object.
+    :param message: The message object to check for.
+    :param check: Optional check function. Must take a `ComponentContext` as the first parameter.
+    :param timeout: The number of seconds to wait before timing out and raising :exc:`asyncio.TimeoutError`.
+    :raises: :exc:`asyncio.TimeoutError`
+    """
     def _check(ctx):
         if check and not check(ctx):
             return False

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,9 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'discord-py-interactions'
-copyright = '2020-2021, eunwoo1104+artem30801+hpenney2'
-author = 'eunwoo1104+artem30801+hpenney2'
+project = 'discord-py-slash-command'
+copyright = '2020-2021, eunwoo1104'
+author = 'eunwoo1104'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,9 +18,9 @@ sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'discord-py-slash-command'
-copyright = '2020-2021, eunwoo1104'
-author = 'eunwoo1104'
+project = 'discord-py-interactions'
+copyright = '2020-2021, eunwoo1104+artem30801+hpenney2'
+author = 'eunwoo1104+artem30801+hpenney2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/discord_slash.utils.manage_components.rst
+++ b/docs/discord_slash.utils.manage_components.rst
@@ -1,0 +1,7 @@
+discord\_slash.utils.manage\_components module
+==============================================
+
+.. automodule:: discord_slash.utils.manage_components
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/discord_slash.utils.rst
+++ b/docs/discord_slash.utils.rst
@@ -8,6 +8,7 @@ Submodules
    :maxdepth: 4
 
    discord_slash.utils.manage_commands
+   discord_slash.utils.manage_components
 
 Module contents
 ---------------

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -20,3 +20,10 @@ These events can be registered to discord.py's listener or
     :param ex: Exception that raised.
     :type ex: Exception
 
+.. function:: on_component(ctx)
+
+    Called when a component is triggered.
+
+    :param ctx: ComponentContext of the triggered component.
+    :type ctx: :class:`.model.ComponentContext`
+


### PR DESCRIPTION
## About this pull request

Merging discord-py-interactions into discord-py-slash-command to add components support

- [X] Added documentation of components
- [ ] Added examples with components

Up to discussion - remove "select" component for now?

## Changes

- Added d.py monkeypatching to add components to all messages 
- Addded functions to generate components 
- Added ComponentContext, extracted common methods/attributes to InteractionContext
- Added component event handling and dispatching
- Added functions to wait for component interactions
Changes from LordOfPolls:
- Slash commands now work with d.py cooldowns
- Refactor of handling d.py checks and cooldowns

## Checklist

- [X] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [X] This adds something new.
- [X] There is/are breaking change(s).
- [X] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
