### PR TITLE
Futher improvements in components implementation

### DIFF
--- a/discord_slash/__init__.py
+++ b/discord_slash/__init__.py
@@ -8,11 +8,12 @@ Simple Discord Slash Command extension for discord.py
 :license: MIT
 """
 
-from .client import SlashCommand  # noqa: F401
-from .const import __version__  # noqa: F401
-from .context import ComponentContext  # noqa: F401
-from .context import SlashContext  # noqa: F401
-from .dpy_overrides import ComponentMessage  # noqa: F401
-from .model import SlashCommandOptionType  # noqa: F401
-from .utils import manage_commands  # noqa: F401
-from .utils import manage_components  # noqa: F401
+from .client import SlashCommand
+from .model import SlashCommandOptionType, ComponentType, ButtonStyle
+from .context import SlashContext
+from .context import ComponentContext
+from .dpy_overrides import ComponentMessage
+from .utils import manage_commands
+from .utils import manage_components
+
+__version__ = "1.2.2"

--- a/discord_slash/__init__.py
+++ b/discord_slash/__init__.py
@@ -8,12 +8,10 @@ Simple Discord Slash Command extension for discord.py
 :license: MIT
 """
 
-from .client import SlashCommand
-from .model import SlashCommandOptionType, ComponentType, ButtonStyle
-from .context import SlashContext
-from .context import ComponentContext
-from .dpy_overrides import ComponentMessage
-from .utils import manage_commands
-from .utils import manage_components
-
-__version__ = "1.2.2"
+from .client import SlashCommand  # noqa: F401
+from .const import __version__  # noqa: F401
+from .context import ComponentContext, SlashContext  # noqa: F401
+from .dpy_overrides import ComponentMessage  # noqa: F401
+from .model import ButtonStyle, ComponentType, SlashCommandOptionType  # noqa: F401
+from .utils import manage_commands  # noqa: F401
+from .utils import manage_components  # noqa: F401

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -278,10 +278,12 @@ class ComponentContext(InteractionContext):
     """
     Context of a component interaction. Has all attributes from :class:`InteractionContext`, plus the component-specific ones below.
 
-    :ivar custom_id: The custom ID of the component.
+    :ivar custom_id: The custom ID of the component (has alias component_id).
     :ivar component_type: The type of the component.
+    :ivar component: Component data retrieved from the message. Not available if the origin message was ephemeral.
     :ivar origin_message: The origin message of the component. Not available if the origin message was ephemeral.
     :ivar origin_message_id: The ID of the origin message.
+
     """
 
     def __init__(
@@ -297,12 +299,15 @@ class ComponentContext(InteractionContext):
         self.origin_message = None
         self.origin_message_id = int(_json["message"]["id"]) if "message" in _json.keys() else None
 
+        self.component = None
+
         self._deferred_edit_origin = False
 
         if self.origin_message_id and (_json["message"]["flags"] & 64) != 64:
             self.origin_message = ComponentMessage(
                 state=self.bot._connection, channel=self.channel, data=_json["message"]
             )
+            self.component = self.origin_message.get_component(self.custom_id)
 
     async def defer(self, hidden: bool = False, edit_origin: bool = False):
         """

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -327,6 +327,24 @@ class ComponentContext(InteractionContext):
         await self._http.post_initial_response(base, self.interaction_id, self._token)
         self.deferred = True
 
+    async def send(self,
+                   content: str = "", *,
+                   embed: discord.Embed = None,
+                   embeds: typing.List[discord.Embed] = None,
+                   tts: bool = False,
+                   file: discord.File = None,
+                   files: typing.List[discord.File] = None,
+                   allowed_mentions: discord.AllowedMentions = None,
+                   hidden: bool = False,
+                   delete_after: float = None,
+                   components: typing.List[dict] = None,
+                   ) -> model.SlashMessage:
+        if self.deferred and self._deferred_edit_origin:
+            self._logger.warning(
+                "Deferred response might not be what you set it to! (edit origin / send response message) "
+                "This is because it was deferred with different response type."
+            )
+
     async def edit_origin(self, **fields):
         """
         Edits the origin message of the component.
@@ -378,7 +396,7 @@ class ComponentContext(InteractionContext):
                 if not self._deferred_edit_origin:
                     self._logger.warning(
                         "Deferred response might not be what you set it to! (edit origin / send response message) "
-                        "This is because it was deferred in a different state."
+                        "This is because it was deferred with different response type."
                     )
                 _json = await self._http.edit(_resp, self._token, files=files)
                 self.deferred = False

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -318,7 +318,9 @@ class ComponentContext(InteractionContext):
 
         if hidden:
             if edit_origin:
-                raise error.IncorrectFormat("'hidden' and 'edit_origin' flags are mutually exclusive")
+                raise error.IncorrectFormat(
+                    "'hidden' and 'edit_origin' flags are mutually exclusive"
+                )
             base["data"] = {"flags": 64}
             self._deferred_hidden = True
 
@@ -327,18 +329,20 @@ class ComponentContext(InteractionContext):
         await self._http.post_initial_response(base, self.interaction_id, self._token)
         self.deferred = True
 
-    async def send(self,
-                   content: str = "", *,
-                   embed: discord.Embed = None,
-                   embeds: typing.List[discord.Embed] = None,
-                   tts: bool = False,
-                   file: discord.File = None,
-                   files: typing.List[discord.File] = None,
-                   allowed_mentions: discord.AllowedMentions = None,
-                   hidden: bool = False,
-                   delete_after: float = None,
-                   components: typing.List[dict] = None,
-                   ) -> model.SlashMessage:
+    async def send(
+        self,
+        content: str = "",
+        *,
+        embed: discord.Embed = None,
+        embeds: typing.List[discord.Embed] = None,
+        tts: bool = False,
+        file: discord.File = None,
+        files: typing.List[discord.File] = None,
+        allowed_mentions: discord.AllowedMentions = None,
+        hidden: bool = False,
+        delete_after: float = None,
+        components: typing.List[dict] = None,
+    ) -> model.SlashMessage:
         if self.deferred and self._deferred_edit_origin:
             self._logger.warning(
                 "Deferred response might not be what you set it to! (edit origin / send response message) "

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -13,7 +13,7 @@ from .dpy_overrides import ComponentMessage
 class InteractionContext:
     """
     Base context for interactions.\n
-    Kinda similar with discord.ext.commands.Context.
+    In some ways similar with discord.ext.commands.Context.
 
     .. warning::
         Do not manually init this model.
@@ -139,7 +139,7 @@ class InteractionContext:
         components: typing.List[dict] = None,
     ) -> model.SlashMessage:
         """
-        Sends response of the slash command.
+        Sends response of the interaction.
 
         .. warning::
             - Since Release 1.0.9, this is completely changed. If you are migrating from older version, please make sure to fix the usage.
@@ -309,7 +309,7 @@ class ComponentContext(InteractionContext):
         'Defers' the response, showing a loading state to the user
 
         :param hidden: Whether the deferred response should be ephemeral . Default ``False``.
-        :param edit_origin: Whether the response is editing the origin message. If ``False``, the deferred response will be for a follow up message. Defaults ``False``.
+        :param edit_origin: Whether the type is editing the origin message. If ``False``, the deferred response will be for a follow up message. Defaults ``False``.
         """
         if self.deferred or self.responded:
             raise error.AlreadyResponded("You have already responded to this command!")

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -344,6 +344,18 @@ class ComponentContext(InteractionContext):
                 "Deferred response might not be what you set it to! (edit origin / send response message) "
                 "This is because it was deferred with different response type."
             )
+        return await super().send(
+            content,
+            embed=embed,
+            embeds=embeds,
+            tts=tts,
+            file=file,
+            files=files,
+            allowed_mentions=allowed_mentions,
+            hidden=hidden,
+            delete_after=delete_after,
+            components=components,
+        )
 
     async def edit_origin(self, **fields):
         """

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -312,7 +312,9 @@ class ComponentContext(InteractionContext):
         if self.deferred or self.responded:
             raise error.AlreadyResponded("You have already responded to this command!")
         base = {"type": 6 if edit_origin else 5}
-        if hidden and not edit_origin:
+        if hidden:
+            if edit_origin:
+                raise error.IncorrectFormat("'hidden' and 'edit_origin' flags are mutually exclusive")
             base["data"] = {"flags": 64}
             self._deferred_hidden = True
         await self._http.post_initial_response(base, self.interaction_id, self._token)

--- a/discord_slash/dpy_overrides.py
+++ b/discord_slash/dpy_overrides.py
@@ -23,9 +23,8 @@ class ComponentMessage(discord.Message):
         """
         for row in self.components:
             for component in row["components"]:
-                if component["custom_id"] == custom_id:
+                if component["custom_id"] is custom_id:
                     return component
-        return None
 
 
 def new_override(cls, *args, **kwargs):

--- a/discord_slash/dpy_overrides.py
+++ b/discord_slash/dpy_overrides.py
@@ -1,3 +1,5 @@
+import typing
+
 import discord
 from discord import AllowedMentions, File, InvalidArgument, abc, http, utils
 from discord.ext import commands
@@ -10,6 +12,20 @@ class ComponentMessage(discord.Message):
     def __init__(self, *, state, channel, data):
         super().__init__(state=state, channel=channel, data=data)
         self.components = data["components"]
+
+    def get_component(self, custom_id: int) -> typing.Optional[dict]:
+        """
+        Returns first component with matching custom_id
+
+        :param custom_id: custom_id of component to get from message components
+        :return: Optional[dict]
+
+        """
+        for row in self.components:
+            for component in row["components"]:
+                if component["custom_id"] == custom_id:
+                    return component
+        return None
 
 
 def new_override(cls, *args, **kwargs):

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -181,7 +181,7 @@ class CommandObject:
         try:
             # cooldown checks
             self._prepare_cooldowns(ctx)
-        except:
+        except Exception:
             if self._max_concurrency is not None:
                 await self._max_concurrency.release(ctx)
             raise

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -1,16 +1,14 @@
 import asyncio
 import datetime
-
-import discord
-from enum import IntEnum
 from contextlib import suppress
+from enum import IntEnum
 from inspect import iscoroutinefunction
 
-from discord.ext.commands import CooldownMapping, CommandOnCooldown
+import discord
+from discord.ext.commands import CommandOnCooldown, CooldownMapping
 
-from . import http
-from . import error
-from . dpy_overrides import ComponentMessage
+from . import error, http
+from .dpy_overrides import ComponentMessage
 
 
 class ChoiceData:
@@ -40,9 +38,7 @@ class OptionData:
     :ivar options: List of :class:`OptionData`, this will be present if it's a subcommand group
     """
 
-    def __init__(
-            self, name, description, required=False, choices=None, options=None, **kwargs
-    ):
+    def __init__(self, name, description, required=False, choices=None, options=None, **kwargs):
         self.name = name
         self.description = description
         self.type = kwargs.get("type")
@@ -83,7 +79,15 @@ class CommandData:
     """
 
     def __init__(
-            self, name, description, options=None, default_permission=True, id=None, application_id=None, version=None, **kwargs
+        self,
+        name,
+        description,
+        options=None,
+        default_permission=True,
+        id=None,
+        application_id=None,
+        version=None,
+        **kwargs
     ):
         self.name = name
         self.description = description
@@ -101,10 +105,10 @@ class CommandData:
     def __eq__(self, other):
         if isinstance(other, CommandData):
             return (
-                    self.name == other.name
-                    and self.description == other.description
-                    and self.options == other.options
-                    and self.default_permission == other.default_permission
+                self.name == other.name
+                and self.description == other.description
+                and self.options == other.options
+                and self.default_permission == other.default_permission
             )
         else:
             return False
@@ -137,7 +141,7 @@ class CommandObject:
         # Since this isn't inherited from `discord.ext.commands.Command`, discord.py's check decorator will
         # add checks at this var.
         self.__commands_checks__ = []
-        if hasattr(self.func, '__commands_checks__'):
+        if hasattr(self.func, "__commands_checks__"):
             self.__commands_checks__ = self.func.__commands_checks__
 
         cooldown = None
@@ -282,7 +286,10 @@ class CommandObject:
         :type ctx: .context.SlashContext
         :return: bool
         """
-        res = [bool(x(ctx)) if not iscoroutinefunction(x) else bool(await x(ctx)) for x in self.__commands_checks__]
+        res = [
+            bool(x(ctx)) if not iscoroutinefunction(x) else bool(await x(ctx))
+            for x in self.__commands_checks__
+        ]
         return False not in res
 
 
@@ -306,6 +313,7 @@ class BaseCommandObject(CommandObject):
         self.has_subcommands = cmd["has_subcommands"]
         self.default_permission = cmd["default_permission"]
         self.permissions = cmd["api_permissions"] or {}
+
 
 class SubcommandObject(CommandObject):
     """
@@ -362,6 +370,7 @@ class SlashCommandOptionType(IntEnum):
     """
     Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.
     """
+
     SUB_COMMAND = 1
     SUB_COMMAND_GROUP = 2
     STRING = 3
@@ -379,13 +388,19 @@ class SlashCommandOptionType(IntEnum):
         :param t: The type or object to get a SlashCommandOptionType for.
         :return: :class:`.model.SlashCommandOptionType` or ``None``
         """
-        if issubclass(t, str): return cls.STRING
-        if issubclass(t, bool): return cls.BOOLEAN
+        if issubclass(t, str):
+            return cls.STRING
+        if issubclass(t, bool):
+            return cls.BOOLEAN
         # The check for bool MUST be above the check for integers as booleans subclass integers
-        if issubclass(t, int): return cls.INTEGER
-        if issubclass(t, discord.abc.User): return cls.USER
-        if issubclass(t, discord.abc.GuildChannel): return cls.CHANNEL
-        if issubclass(t, discord.abc.Role): return cls.ROLE
+        if issubclass(t, int):
+            return cls.INTEGER
+        if issubclass(t, discord.abc.User):
+            return cls.USER
+        if issubclass(t, discord.abc.GuildChannel):
+            return cls.CHANNEL
+        if issubclass(t, discord.abc.Role):
+            return cls.ROLE
 
 
 class SlashMessage(ComponentMessage):
@@ -432,8 +447,13 @@ class SlashMessage(ComponentMessage):
             _resp["embeds"] = [x.to_dict() for x in embeds]
 
         allowed_mentions = fields.get("allowed_mentions")
-        _resp["allowed_mentions"] = allowed_mentions.to_dict() if allowed_mentions else \
-            self._state.allowed_mentions.to_dict() if self._state.allowed_mentions else {}
+        _resp["allowed_mentions"] = (
+            allowed_mentions.to_dict()
+            if allowed_mentions
+            else self._state.allowed_mentions.to_dict()
+            if self._state.allowed_mentions
+            else {}
+        )
 
         await self._http.edit(_resp, self.__interaction_token, self.id, files=files)
 
@@ -477,6 +497,7 @@ class PermissionData:
     :ivar type: The ``SlashCommandPermissionsType`` type of this permission.
     :ivar permission: State of permission. ``True`` to allow, ``False`` to disallow.
     """
+
     def __init__(self, id, type, permission, **kwargs):
         self.id = id
         self.type = type
@@ -498,9 +519,10 @@ class GuildPermissionsData:
     Slash permissions data for a command in a guild.
 
     :ivar id: Command id, provided by discord.
-    :ivar guild_id: Guild id that the permissions are in. 
+    :ivar guild_id: Guild id that the permissions are in.
     :ivar permissions: List of permissions dict.
     """
+
     def __init__(self, id, guild_id, permissions, **kwargs):
         self.id = id
         self.guild_id = guild_id
@@ -524,13 +546,16 @@ class SlashCommandPermissionType(IntEnum):
     """
     Equivalent of `ApplicationCommandPermissionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissiontype>`_  in the Discord API.
     """
+
     ROLE = 1
     USER = 2
 
     @classmethod
     def from_type(cls, t: type):
-        if issubclass(t, discord.abc.Role): return cls.ROLE
-        if issubclass(t, discord.abc.User): return cls.USER
+        if issubclass(t, discord.abc.Role):
+            return cls.ROLE
+        if issubclass(t, discord.abc.User):
+            return cls.USER
 
 
 class ComponentType(IntEnum):

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -1,14 +1,16 @@
 import asyncio
 import datetime
-from contextlib import suppress
-from enum import IntEnum
-from inspect import iscoroutinefunction
 
 import discord
-from discord.ext.commands import CommandOnCooldown, CooldownMapping
+from enum import IntEnum
+from contextlib import suppress
+from inspect import iscoroutinefunction
 
-from . import error, http
-from .dpy_overrides import ComponentMessage
+from discord.ext.commands import CooldownMapping, CommandOnCooldown
+
+from . import http
+from . import error
+from . dpy_overrides import ComponentMessage
 
 
 class ChoiceData:
@@ -38,7 +40,9 @@ class OptionData:
     :ivar options: List of :class:`OptionData`, this will be present if it's a subcommand group
     """
 
-    def __init__(self, name, description, required=False, choices=None, options=None, **kwargs):
+    def __init__(
+            self, name, description, required=False, choices=None, options=None, **kwargs
+    ):
         self.name = name
         self.description = description
         self.type = kwargs.get("type")
@@ -79,15 +83,7 @@ class CommandData:
     """
 
     def __init__(
-        self,
-        name,
-        description,
-        options=None,
-        default_permission=True,
-        id=None,
-        application_id=None,
-        version=None,
-        **kwargs
+            self, name, description, options=None, default_permission=True, id=None, application_id=None, version=None, **kwargs
     ):
         self.name = name
         self.description = description
@@ -105,10 +101,10 @@ class CommandData:
     def __eq__(self, other):
         if isinstance(other, CommandData):
             return (
-                self.name == other.name
-                and self.description == other.description
-                and self.options == other.options
-                and self.default_permission == other.default_permission
+                    self.name == other.name
+                    and self.description == other.description
+                    and self.options == other.options
+                    and self.default_permission == other.default_permission
             )
         else:
             return False
@@ -141,7 +137,7 @@ class CommandObject:
         # Since this isn't inherited from `discord.ext.commands.Command`, discord.py's check decorator will
         # add checks at this var.
         self.__commands_checks__ = []
-        if hasattr(self.func, "__commands_checks__"):
+        if hasattr(self.func, '__commands_checks__'):
             self.__commands_checks__ = self.func.__commands_checks__
 
         cooldown = None
@@ -181,7 +177,7 @@ class CommandObject:
         try:
             # cooldown checks
             self._prepare_cooldowns(ctx)
-        except Exception:
+        except:
             if self._max_concurrency is not None:
                 await self._max_concurrency.release(ctx)
             raise
@@ -286,10 +282,7 @@ class CommandObject:
         :type ctx: .context.SlashContext
         :return: bool
         """
-        res = [
-            bool(x(ctx)) if not iscoroutinefunction(x) else bool(await x(ctx))
-            for x in self.__commands_checks__
-        ]
+        res = [bool(x(ctx)) if not iscoroutinefunction(x) else bool(await x(ctx)) for x in self.__commands_checks__]
         return False not in res
 
 
@@ -313,7 +306,6 @@ class BaseCommandObject(CommandObject):
         self.has_subcommands = cmd["has_subcommands"]
         self.default_permission = cmd["default_permission"]
         self.permissions = cmd["api_permissions"] or {}
-
 
 class SubcommandObject(CommandObject):
     """
@@ -370,7 +362,6 @@ class SlashCommandOptionType(IntEnum):
     """
     Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.
     """
-
     SUB_COMMAND = 1
     SUB_COMMAND_GROUP = 2
     STRING = 3
@@ -388,19 +379,13 @@ class SlashCommandOptionType(IntEnum):
         :param t: The type or object to get a SlashCommandOptionType for.
         :return: :class:`.model.SlashCommandOptionType` or ``None``
         """
-        if issubclass(t, str):
-            return cls.STRING
-        if issubclass(t, bool):
-            return cls.BOOLEAN
+        if issubclass(t, str): return cls.STRING
+        if issubclass(t, bool): return cls.BOOLEAN
         # The check for bool MUST be above the check for integers as booleans subclass integers
-        if issubclass(t, int):
-            return cls.INTEGER
-        if issubclass(t, discord.abc.User):
-            return cls.USER
-        if issubclass(t, discord.abc.GuildChannel):
-            return cls.CHANNEL
-        if issubclass(t, discord.abc.Role):
-            return cls.ROLE
+        if issubclass(t, int): return cls.INTEGER
+        if issubclass(t, discord.abc.User): return cls.USER
+        if issubclass(t, discord.abc.GuildChannel): return cls.CHANNEL
+        if issubclass(t, discord.abc.Role): return cls.ROLE
 
 
 class SlashMessage(ComponentMessage):
@@ -447,13 +432,8 @@ class SlashMessage(ComponentMessage):
             _resp["embeds"] = [x.to_dict() for x in embeds]
 
         allowed_mentions = fields.get("allowed_mentions")
-        _resp["allowed_mentions"] = (
-            allowed_mentions.to_dict()
-            if allowed_mentions
-            else self._state.allowed_mentions.to_dict()
-            if self._state.allowed_mentions
-            else {}
-        )
+        _resp["allowed_mentions"] = allowed_mentions.to_dict() if allowed_mentions else \
+            self._state.allowed_mentions.to_dict() if self._state.allowed_mentions else {}
 
         await self._http.edit(_resp, self.__interaction_token, self.id, files=files)
 
@@ -497,7 +477,6 @@ class PermissionData:
     :ivar type: The ``SlashCommandPermissionsType`` type of this permission.
     :ivar permission: State of permission. ``True`` to allow, ``False`` to disallow.
     """
-
     def __init__(self, id, type, permission, **kwargs):
         self.id = id
         self.type = type
@@ -519,10 +498,9 @@ class GuildPermissionsData:
     Slash permissions data for a command in a guild.
 
     :ivar id: Command id, provided by discord.
-    :ivar guild_id: Guild id that the permissions are in.
+    :ivar guild_id: Guild id that the permissions are in. 
     :ivar permissions: List of permissions dict.
     """
-
     def __init__(self, id, guild_id, permissions, **kwargs):
         self.id = id
         self.guild_id = guild_id
@@ -546,13 +524,31 @@ class SlashCommandPermissionType(IntEnum):
     """
     Equivalent of `ApplicationCommandPermissionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandpermissiontype>`_  in the Discord API.
     """
-
     ROLE = 1
     USER = 2
 
     @classmethod
     def from_type(cls, t: type):
-        if issubclass(t, discord.abc.Role):
-            return cls.ROLE
-        if issubclass(t, discord.abc.User):
-            return cls.USER
+        if issubclass(t, discord.abc.Role): return cls.ROLE
+        if issubclass(t, discord.abc.User): return cls.USER
+
+
+class ComponentType(IntEnum):
+    actionrow = 1
+    button = 2
+    select = 3
+
+
+class ButtonStyle(IntEnum):
+    blue = 1
+    blurple = 1
+    gray = 2
+    grey = 2
+    green = 3
+    red = 4
+    URL = 5
+
+    primary = 1
+    secondary = 2
+    success = 3
+    danger = 4

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -3,7 +3,7 @@ import enum
 import typing
 import discord
 from ..context import ComponentContext
-from ..error import IncorrectFormat
+from ..error import IncorrectFormat, IncorrectType
 
 
 class ComponentsType(enum.IntEnum):
@@ -187,7 +187,7 @@ def get_components_ids(component: typing.Union[str, dict, list]) -> typing.Itera
         # Either list of components (actionrows or buttons) or list of ids
         yield from (comp_id for comp in component for comp_id in get_components_ids(comp))
     else:
-        raise IncorrectFormat(
+        raise IncorrectType(
             f"Unknown component type of {component} ({type(component)}). "
             f"Expected str, dict or list"
         )
@@ -201,7 +201,7 @@ def _get_messages_ids(message: typing.Union[discord.Message, int, list]) -> typi
     elif isinstance(message, list):
         yield from (msg_id for msg in message for msg_id in _get_messages_ids(msg))
     else:
-        raise IncorrectFormat(
+        raise IncorrectType(
             f"Unknown component type of {message} ({type(message)}). "
             f"Expected discord.Message, int or list"
         )

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -1,9 +1,11 @@
-import uuid
 import typing
+import uuid
+
 import discord
+
 from ..context import ComponentContext
 from ..error import IncorrectFormat, IncorrectType
-from ..model import ComponentType, ButtonStyle
+from ..model import ButtonStyle, ComponentType
 
 
 def create_actionrow(*components: dict) -> dict:

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -1,15 +1,9 @@
 import uuid
-import enum
 import typing
 import discord
 from ..context import ComponentContext
 from ..error import IncorrectFormat, IncorrectType
-
-
-class ComponentsType(enum.IntEnum):
-    actionrow = 1
-    button = 2
-    select = 3
+from ..model import ComponentType, ButtonStyle
 
 
 def create_actionrow(*components: dict) -> dict:
@@ -22,27 +16,12 @@ def create_actionrow(*components: dict) -> dict:
     if not components or len(components) > 5:
         raise IncorrectFormat("Number of components in one row should be between 1 and 5.")
     if (
-        ComponentsType.select in [component["type"] for component in components]
+        ComponentType.select in [component["type"] for component in components]
         and len(components) > 1
     ):
         raise IncorrectFormat("Action row must have only one select component and nothing else")
 
-    return {"type": ComponentsType.actionrow, "components": components}
-
-
-class ButtonStyle(enum.IntEnum):
-    blue = 1
-    blurple = 1
-    gray = 2
-    grey = 2
-    green = 3
-    red = 4
-    URL = 5
-
-    primary = 1
-    secondary = 2
-    success = 3
-    danger = 4
+    return {"type": ComponentType.actionrow, "components": components}
 
 
 def emoji_to_dict(emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str]) -> dict:
@@ -101,7 +80,7 @@ def create_button(
     emoji = emoji_to_dict(emoji)
 
     data = {
-        "type": ComponentsType.button,
+        "type": ComponentType.button,
         "style": style,
     }
 
@@ -160,7 +139,7 @@ def create_select(
         raise IncorrectFormat("Options length should be between 1 and 25.")
 
     return {
-        "type": ComponentsType.select,
+        "type": ComponentType.select,
         "options": options,
         "custom_id": custom_id or str(uuid.uuid4()),
         "placeholder": placeholder or "",
@@ -179,7 +158,7 @@ def get_components_ids(component: typing.Union[str, dict, list]) -> typing.Itera
     if isinstance(component, str):
         yield component
     elif isinstance(component, dict):
-        if component["type"] == ComponentsType.actionrow:
+        if component["type"] == ComponentType.actionrow:
             yield from (comp["custom_id"] for comp in component["components"])
         else:
             yield component["custom_id"]

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -21,13 +21,13 @@ def create_actionrow(*components: dict) -> dict:
     """
     if not components or len(components) > 5:
         raise IncorrectFormat("Number of components in one row should be between 1 and 5.")
-    if ComponentsType.select in [component["type"] for component in components] and len(components) > 1:
+    if (
+        ComponentsType.select in [component["type"] for component in components]
+        and len(components) > 1
+    ):
         raise IncorrectFormat("Action row must have only one select component and nothing else")
 
-    return {
-        "type": ComponentsType.actionrow,
-        "components": components
-    }
+    return {"type": ComponentsType.actionrow, "components": components}
 
 
 class ButtonStyle(enum.IntEnum):
@@ -59,12 +59,14 @@ def emoji_to_dict(emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str])
     return emoji if emoji else {}
 
 
-def create_button(style: typing.Union[ButtonStyle, int],
-                  label: str = None,
-                  emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str] = None,
-                  custom_id: str = None,
-                  url: str = None,
-                  disabled: bool = False) -> dict:
+def create_button(
+    style: typing.Union[ButtonStyle, int],
+    label: str = None,
+    emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str] = None,
+    custom_id: str = None,
+    url: str = None,
+    disabled: bool = False,
+) -> dict:
     """
     Creates a button component for use with the ``components`` field. Must be inside an ActionRow to be used (see :meth:`create_actionrow`).
 
@@ -118,7 +120,9 @@ def create_button(style: typing.Union[ButtonStyle, int],
     return data
 
 
-def create_select_option(label: str, value: str, emoji=None, description: str = None, default: bool = False):
+def create_select_option(
+    label: str, value: str, emoji=None, description: str = None, default: bool = False
+):
     """
     Creates an option for select components.
 
@@ -135,11 +139,17 @@ def create_select_option(label: str, value: str, emoji=None, description: str = 
         "value": value,
         "description": description,
         "default": default,
-        "emoji": emoji
+        "emoji": emoji,
     }
 
 
-def create_select(options: typing.List[dict], custom_id=None, placeholder=None, min_values=None, max_values=None):
+def create_select(
+    options: typing.List[dict],
+    custom_id=None,
+    placeholder=None,
+    min_values=None,
+    max_values=None,
+):
     """
     Creates a select (dropdown) component for use with the ``components`` field. Must be inside an ActionRow to be used (see :meth:`create_actionrow`).
 
@@ -177,12 +187,18 @@ def get_components_ids(component: typing.Union[str, dict, list]) -> typing.Gener
         # Either list of components (actionrows or buttons) or list of ids
         yield from (comp_id for comp in component for comp_id in get_components_ids(comp))
     else:
-        raise IncorrectFormat(f"Unknown component type of {component} ({type(component)}). "
-                              f"Expected str, dict or list")
+        raise IncorrectFormat(
+            f"Unknown component type of {component} ({type(component)}). "
+            f"Expected str, dict or list"
+        )
 
 
-async def wait_for_component(client: discord.Client, component: typing.Union[str, dict, list], check=None, timeout=None) \
-        -> ComponentContext:
+async def wait_for_component(
+    client: discord.Client,
+    component: typing.Union[str, dict, list],
+    check=None,
+    timeout=None,
+) -> ComponentContext:
     """
     Waits for a component interaction. Only accepts interactions based on the custom ID of the component, and optionally a check function.
 
@@ -200,14 +216,19 @@ async def wait_for_component(client: discord.Client, component: typing.Union[str
     def _check(ctx):
         if check and not check(ctx):
             return False
-        wanted_component = ctx.custom_id in components_ids or not components_ids  # if matches or components_ids empty
+        # if matches or components_ids empty
+        wanted_component = ctx.custom_id in components_ids or not components_ids
         return wanted_component
 
     return await client.wait_for("component", check=_check, timeout=timeout)
 
 
-async def wait_for_any_component(client: discord.Client, message: typing.Union[discord.Message, int],
-                                 check=None, timeout=None) -> ComponentContext:
+async def wait_for_any_component(
+    client: discord.Client,
+    message: typing.Union[discord.Message, int],
+    check=None,
+    timeout=None,
+) -> ComponentContext:
     """
     Waits for any component interaction. Only accepts interactions based on the message ID given and optionally a check function.
 
@@ -223,6 +244,8 @@ async def wait_for_any_component(client: discord.Client, message: typing.Union[d
     def _check(ctx):
         if check and not check(ctx):
             return False
-        return (message.id if isinstance(message, discord.Message) else message) == ctx.origin_message_id
+        return (
+            message.id if isinstance(message, discord.Message) else message
+        ) == ctx.origin_message_id
 
     return await client.wait_for("component", check=_check, timeout=timeout)


### PR DESCRIPTION
## About this pull request

Futher improvements in components implementation
Cherry-picked commits from previous draft to improve commit log

## Changes

- Support for both message and components as kwargs in wait_for_component
- Support for actionrows and lists of actionrows in wait_for_component
- Exception for hidden+edit_origin in defer
- Warning for edit_origin=True defer when sending response
- Warning for edit_origin=False defer when calling edit_origin
- Move component enums to models
- Added component attribute to ComponentContext

What changes were made?

## Checklist

- [X] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [X] This adds something new.
- [X] There is/are breaking change(s).
- [X] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
