### PR TITLE
Allow for error handling with functions with the @(func_name).error decorator

### DIFF
--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -1,6 +1,6 @@
 import typing
 import inspect
-from .model import CogBaseCommandObject, CogSubcommandObject
+from .model import NewCogBaseCommandObject, NewCogSubcommandObject
 from .utils import manage_commands
 
 
@@ -60,7 +60,7 @@ def cog_slash(*,
             "connector": connector,
             "has_subcommands": False
         }
-        return CogBaseCommandObject(name or cmd.__name__, _cmd)
+        return NewCogBaseCommandObject(name or cmd.__name__, _cmd)
     return wrapper
 
 
@@ -151,5 +151,5 @@ def cog_subcommand(*,
             "api_options": opts,
             "connector": connector
         }
-        return CogSubcommandObject(base, _cmd, subcommand_group, name or cmd.__name__, _sub)
+        return NewCogSubcommandObject(base, _cmd, subcommand_group, name or cmd.__name__, _sub)
     return wrapper


### PR DESCRIPTION
## About this pull request

Allow for handling of errors raised during the execution of a slash command with the @(func_name).error decorator
Inspired by discord.py's cog command object that allowed for this

## Changes

Created the NewCogBaseCommandObject (child class of CogBaseCommandObject)
Created the NewCogSubcommandObject (child class of CogSubcommandObject)

Both of these have the error function to allow for handling an error from that command with the @(func_name).error decorator

Change cog_ext.py to create NewCogBaseCommandObject's and NewCogSubcommandObject's (instead of CogBaseCommandObject's and CogSubcommandObject's)

Note: NewCogBaseCommandObject and NewCogSubcommandObject both have a help attribute, retrieved from the function's docstring, similar to discord.py's cog command object's help attribute.

## Example Implementation:
(your cog name).py
```
@cog_ext.cog_slash(name="example", description="our example", ...)
def example(self, ctx):
    ... # your command's code here
@example.error
def example_error(self, ctx, exc):
    ... # your error handler's code here
    ... # example: if isinstance(exc, CheckFailure): await ctx.send("custom message")
```

(your bot location).py  -  a function similar to this would implement the use of @(....).error decorators before functions.
```
async def on_slash_command_error(self, ctx, exc):
        """
        This is the slash_cmd error handler
        If an existing error handler is found, dispatches the error
        handling to that error handler. If not, raises the error
        """
        func_name = ctx.name
        subcmd_name = ctx.subcommand_name
        all_commands = self.slash.commands
        all_sub_cmds = {
            name: func
            for i in self.slash.subcommands.values()
            for name, func in i.items()
        }

        # a different slash_obj is retrieved depending on if it is a subcmd or not
        # (note that slash_obj refers to a class that has invoke and on_error methods
        # similar to C4TCogSlashBase)
        if subcmd_name is None:
            try:  # try to handle it if it is a command
                slash_obj = all_commands[func_name]
            except Exception as e:
                print("Exception that happened when handling error:", e)
                raise exc
        else:
            try:  # try to handle it if it is a subcommand
                slash_obj = all_sub_cmds[subcmd_name]
            except Exception as e:
                print("Exception that happened when handling error:", e)
                raise exc
        
        try:
            error_handler = slash_obj.on_error
            # print("error_handler:", error_handler)
            error_handler_name = error_handler.__name__
            cog_obj = None
            for cog in self.cogs.values():
                boolean = hasattr(cog, error_handler_name)
                if boolean:
                    cog_obj = cog

            await slash_obj.on_error(cog_obj, ctx, exc)
        except:
            # happens if no error handler was found
            # you can put a pass here instead of the raise exc and then put your code
            # if you want your on_slash_command_error to do more than just dispatch
            # error handling to the slash_obj's error handlers
            raise exc
```

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [x] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
