### PR TITLE
Components callbacks

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -894,8 +894,7 @@ class SlashCommand:
         Callback can be made to only accept component interactions from a specific messages
         and/or custom_ids of components.
 
-        :param callback: The coroutine to be called when the component is interacted with. Must accept a single argument with the type :class:`.context.ComponentContext`.
-        :type callback: Coroutine
+        :param Coroutine callback: The coroutine to be called when the component is interacted with. Must accept a single argument with the type :class:`.context.ComponentContext`.
         :param messages: If specified, only interactions from the message given will be accepted. Can be a message object to check for, or the message ID or list of previous two. Empty list will mean that no interactions are accepted.
         :type messages: Union[discord.Message, int, list]
         :param components: If specified, only interactions with ``custom_id``s of given components will be accepted. Defaults to the name of ``callback`` if ``use_callback_name=True``. Can be a custom ID (str) or component dict (actionrow or button) or list of previous two.
@@ -1050,7 +1049,7 @@ class SlashCommand:
         component_type: int = None,
     ):
         """
-        Decorator that registers a coroutine as a component callback.\n
+        Decorator that registers a coroutine as a component callback.
         Adds a coroutine callback to a component.
         Callback can be made to only accept component interactions from a specific messages
         and/or custom_ids of components.

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -911,7 +911,7 @@ class SlashCommand:
         :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
         If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
         :type use_callback_name: bool
-        :param component_type: The type of the component to avoid collisions with other component types. See :class:`.utils.manage_components.ComponentsType`.
+        :param component_type: The type of the component to avoid collisions with other component types. See :class:`.model.ComponentType`.
         :type component_type: Optional[int]
         :raises: .error.DuplicateCustomID, .error.IncorrectFormat
         """
@@ -967,7 +967,7 @@ class SlashCommand:
         custom_id: str = None,
     ):
         """
-        Registers existing callback object (:class:`.utils.manage_components.ComponentsType`)
+        Registers existing callback object (:class:`.model.ComponentType`)
         for specific combination of message_id, custom_id, component_type.
 
         :param callback_obj: callback object.
@@ -996,7 +996,7 @@ class SlashCommand:
         :type message_id: Optional[.model]
         :param custom_id: The `custom_id` of the component.
         :type custom_id: Optional[str]
-        :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
+        :param component_type: The type of the component. See :class:`.model.ComponentType`.
         :type component_type: Optional[int]
 
         :return: Optional[model.ComponentCallbackObject]
@@ -1022,7 +1022,7 @@ class SlashCommand:
         :type message_id: Optional[int]
         :param custom_id: The `custom_id` of the component.
         :type custom_id: Optional[str]
-        :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
+        :param component_type: The type of the component. See :class:`.model.ComponentType`.
         :type component_type: Optional[int]
         :raises: .error.IncorrectFormat
         """
@@ -1087,7 +1087,7 @@ class SlashCommand:
         :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
         If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
         :type use_callback_name: bool
-        :param component_type: The type of the component to avoid collisions with other component types. See :class:`.utils.manage_components.ComponentsType`.
+        :param component_type: The type of the component to avoid collisions with other component types. See :class:`.model.ComponentType`.
         :type component_type: Optional[int]
         :raises: .error.DuplicateCustomID, .error.IncorrectFormat
         """

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -908,8 +908,7 @@ class SlashCommand:
         :type custom_id: Optional[str]
         :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead. Empty list will mean that no interactions are accepted.
         :type custom_ids: Optional[List[str]]
-        :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
-        If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
+        :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified. If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
         :type use_callback_name: bool
         :param component_type: The type of the component to avoid collisions with other component types. See :class:`.model.ComponentType`.
         :type component_type: Optional[int]
@@ -1084,8 +1083,7 @@ class SlashCommand:
         :type custom_id: Optional[str]
         :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead. Empty list will mean that no interactions are accepted.
         :type custom_ids: Optional[List[str]]
-        :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
-        If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
+        :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified. If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
         :type use_callback_name: bool
         :param component_type: The type of the component to avoid collisions with other component types. See :class:`.model.ComponentType`.
         :type component_type: Optional[int]

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -961,7 +961,10 @@ class SlashCommand:
         )
 
     def extend_component_callback(
-        self, callback_obj: model.ComponentCallbackObject, message_id: int = None, custom_id: str = None
+        self,
+        callback_obj: model.ComponentCallbackObject,
+        message_id: int = None,
+        custom_id: str = None,
     ):
         """
         Registers existing callback object (:class:`.utils.manage_components.ComponentsType`)

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -8,7 +8,7 @@ import discord
 from discord.ext import commands
 
 from . import context, error, http, model
-from .utils import manage_commands, manage_components
+from .utils import manage_commands
 
 
 def _get_val(d: dict, key):  # util function to get value from dict with fallback to None key
@@ -1328,7 +1328,7 @@ class SlashCommand:
         await self.invoke_command(selected, ctx, args)
 
     def _on_error(self, ctx, ex, event_name):
-        on_event = "on_"+event_name
+        on_event = "on_" + event_name
         if self.has_listener:
             if self._discord.extra_events.get(on_event):
                 self._discord.dispatch(event_name, ctx, ex)
@@ -1366,7 +1366,9 @@ class SlashCommand:
         """
         if not self._on_error(ctx, ex, "slash_command_error"):
             # Prints exception if not overridden or has no listener for error.
-            self.logger.exception(f"An exception has occurred while executing command `{ctx.name}`:")
+            self.logger.exception(
+                f"An exception has occurred while executing command `{ctx.name}`:"
+            )
 
     async def on_component_callback_error(self, ctx, ex):
         """
@@ -1396,4 +1398,6 @@ class SlashCommand:
         """
         if not self._on_error(ctx, ex, "component_callback_error"):
             # Prints exception if not overridden or has no listener for error.
-            self.logger.exception(f"An exception has occurred while executing component callback custom ID `{ctx.custom_id}`:")
+            self.logger.exception(
+                f"An exception has occurred while executing component callback custom ID `{ctx.custom_id}`:"
+            )

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -893,14 +893,23 @@ class SlashCommand:
         """
         Adds a coroutine callback to a component. Optionally, this can be made to only accept component interactions from a specific message.
 
+        .. note::
+            ``message_id`` and ``message_ids`` cannot be used at the same time. The same applies to ``custom_id`` and ``custom_ids``.
+
         :param callback: The coroutine to be called when the component is interacted with. Must accept a single argument with the type :class:`.context.ComponentContext`.
         :type callback: Coroutine
-        :param custom_id: The `custom_id` of the component. Defaults to the name of `callback`.
-        :type custom_id: str
-        :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
-        :type component_type: int
         :param message_id: If specified, only interactions from the message given will be accepted.
         :type message_id: Optional[int]
+        :param message_ids: Similar to ``message_id``, but accepts a list of message IDs instead.
+        :type message_ids: Optional[List[int]]
+        :param custom_id: The ``custom_id`` of the component. Defaults to the name of ``callback`` if ``use_callback_name=True``.
+        :type custom_id: Optional[str]
+        :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead.
+        :type custom_ids: Optional[List[str]]
+        :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
+        :type use_callback_name: bool
+        :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
+        :type component_type: Optional[int]
         :raises: .error.DuplicateCustomID
         """
         if message_id and message_ids:
@@ -979,9 +988,9 @@ class SlashCommand:
         Removes a component callback. If the `message_id` is specified, only removes the callback for the specific message ID.
 
         :param custom_id: The `custom_id` of the component.
-        :type custom_id: str
+        :type custom_id: Optional[str]
         :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
-        :type component_type: int
+        :type component_type: Optional[int]
         :param message_id: If specified, only removes the callback for the specific message ID.
         :type message_id: Optional[int]
         :raises: .error.IncorrectFormat
@@ -995,7 +1004,7 @@ class SlashCommand:
         except KeyError:
             raise error.IncorrectFormat(
                 f"Callback for "
-                f"message ID {message_id or '<any>'}, "
+                f"message ID `{message_id or '<any>'}`, "
                 f"custom_id `{custom_id or '<any>'}`, "
                 f"component_type `{component_type or '<any>'}` is not registered!"
             )
@@ -1038,14 +1047,18 @@ class SlashCommand:
         .. note::
             `message_id` and `message_ids` cannot be used at the same time.
 
-        :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
-        :type component_type: Union[int, manage_components.ComponentsType]
-        :param custom_id: The `custom_id` of the component. Defaults to the name of coroutine being decorated.
-        :type custom_id: str
         :param message_id: If specified, only interactions from the message given will be accepted.
         :type message_id: Optional[int]
-        :param message_ids: Acts like `message_id`, but accepts a list of message IDs instead.
+        :param message_ids: Similar to ``message_id``, but accepts a list of message IDs instead.
         :type message_ids: Optional[List[int]]
+        :param custom_id: The ``custom_id`` of the component. Defaults to the name of ``callback`` if ``use_callback_name=True``.
+        :type custom_id: Optional[str]
+        :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead.
+        :type custom_ids: Optional[List[str]]
+        :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
+        :type use_callback_name: bool
+        :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
+        :type component_type: Optional[int]
         :raises: .error.IncorrectFormat
         """
 
@@ -1167,9 +1180,9 @@ class SlashCommand:
 
     async def invoke_component_callback(self, func, ctx):
         """
-        Invokes command.
+        Invokes component callback.
 
-        :param func: Component callback coroutine.
+        :param func: Component callback object.
         :param ctx: Context.
         """
         try:

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -1199,10 +1199,9 @@ class SlashCommand:
         callback = self.get_component_callback(
             ctx.origin_message_id, ctx.custom_id, ctx.component_type
         )
-        print(callback)
-        print(self.components)
         if callback is not None:
-            return await callback.invoke(ctx)
+            self._discord.dispatch("component_callback", ctx, callback)
+            await callback.invoke(ctx)
 
     async def _on_slash(self, to_use):
         if to_use["data"]["name"] in self.commands:

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -987,7 +987,7 @@ class SlashCommand:
         :raises: .error.IncorrectFormat
         """
         try:
-            self.components[message_id][custom_id].pop(component_type)
+            callback = self.components[message_id][custom_id].pop(component_type)
             if not self.components[message_id][custom_id]:  # delete dict nesting levels if empty
                 self.components[message_id].pop(custom_id)
                 if not self.components[message_id]:
@@ -999,6 +999,9 @@ class SlashCommand:
                 f"custom_id `{custom_id or '<any>'}`, "
                 f"component_type `{component_type or '<any>'}` is not registered!"
             )
+        else:
+            callback.message_ids.remove(message_id)
+            callback.custom_ids.remove(custom_id)
 
     def remove_component_callback_obj(self, callback_obj: model.ComponentCallbackObject):
         """

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -179,22 +179,16 @@ def cog_component(
     if custom_id and custom_ids:
         raise error.IncorrectFormat("You cannot use both `custom_id` and `custom_ids`!")
 
-    if message_id:
+    if message_ids is None:
         message_ids = [message_id]
-
-    if custom_id:
-        custom_ids = [custom_id]
-
-    if component_type not in (2, 3, None):
-        raise error.IncorrectFormat(f"Invalid component type `{component_type}`")
 
     def wrapper(callback):
         nonlocal custom_ids
 
-        if use_callback_name:
-            custom_ids = custom_ids or [callback.__name__]
+        if custom_ids is None:
+            custom_ids = [callback.__name__] if use_callback_name else [custom_id]
 
-        if not (message_ids or custom_ids):
+        if message_ids == [None] and custom_ids == [None]:
             raise error.IncorrectFormat(
                 "'message_ids' ('message_id') or 'custom_ids' ('custom_id') must be specified!"
             )

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -178,21 +178,22 @@ def cog_component(
     Almost same as :meth:`.client.SlashCommand.component_callback`.
 
     .. note::
-        ``message_id`` and ``message_ids`` cannot be used at the same time.
+        ``message_id`` and ``message_ids`` cannot be used at the same time. The same applies to ``custom_id`` and ``custom_ids``.
 
     :param message_id: If specified, only interactions from the message given will be accepted.
     :type message_id: Optional[int]
-    :param message_ids: Similar to ``message_id``, but accepts a list of message IDs instead.
+    :param message_ids: Similar to ``message_id``, but accepts a list of message IDs instead. Empty list will mean that no interactions are accepted.
     :type message_ids: Optional[List[int]]
     :param custom_id: The ``custom_id`` of the component. Defaults to the name of ``callback`` if ``use_callback_name=True``.
     :type custom_id: Optional[str]
-    :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead.
+    :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead. Empty list will mean that no interactions are accepted.
     :type custom_ids: Optional[List[str]]
     :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
+    If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
     :type use_callback_name: bool
-    :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
+    :param component_type: The type of the component to avoid collisions with other component types. See :class:`.utils.manage_components.ComponentsType`.
     :type component_type: Optional[int]
-    :raises: .error.IncorrectFormat
+    :raises: .error.DuplicateCustomID, .error.IncorrectFormat
     """
     if message_id and message_ids:
         raise error.IncorrectFormat("You cannot use both `message_id` and `message_ids`!")

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -1,9 +1,12 @@
 import inspect
 import typing
 
+import discord
+
 from . import error
 from .model import CogBaseCommandObject, CogComponentCallbackObject, CogSubcommandObject
 from .utils import manage_commands
+from .utils.manage_components import get_components_ids, get_messages_ids
 
 
 def cog_slash(
@@ -166,10 +169,8 @@ def cog_subcommand(
 
 def cog_component(
     *,
-    message_id: int = None,
-    message_ids: typing.List[int] = None,
-    custom_id: str = None,
-    custom_ids: typing.List[str] = None,
+    messages: typing.Union[int, discord.Message, list] = None,
+    components: typing.Union[str, dict, list] = None,
     use_callback_name=True,
     component_type: int = None,
 ):
@@ -177,42 +178,27 @@ def cog_component(
     Decorator for component callbacks in cogs.\n
     Almost same as :meth:`.client.SlashCommand.component_callback`.
 
-    .. note::
-        ``message_id`` and ``message_ids`` cannot be used at the same time. The same applies to ``custom_id`` and ``custom_ids``.
-
-    :param message_id: If specified, only interactions from the message given will be accepted.
-    :type message_id: Optional[int]
-    :param message_ids: Similar to ``message_id``, but accepts a list of message IDs instead. Empty list will mean that no interactions are accepted.
-    :type message_ids: Optional[List[int]]
-    :param custom_id: The ``custom_id`` of the component. Defaults to the name of ``callback`` if ``use_callback_name=True``.
-    :type custom_id: Optional[str]
-    :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead. Empty list will mean that no interactions are accepted.
-    :type custom_ids: Optional[List[str]]
-    :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified. If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
+    :param messages: If specified, only interactions from the message given will be accepted. Can be a message object to check for, or the message ID or list of previous two. Empty list will mean that no interactions are accepted.
+    :type messages: Union[discord.Message, int, list]
+    :param components: If specified, only interactions with ``custom_id``s of given components will be accepted. Defaults to the name of ``callback`` if ``use_callback_name=True``. Can be a custom ID (str) or component dict (actionrow or button) or list of previous two.
+    :type components: Union[str, dict, list]
+    :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified. If ``False``, either `messages`` or ``components`` must be specified.
     :type use_callback_name: bool
     :param component_type: The type of the component to avoid collisions with other component types. See :class:`.model.ComponentType`.
     :type component_type: Optional[int]
     :raises: .error.DuplicateCustomID, .error.IncorrectFormat
     """
-    if message_id and message_ids:
-        raise error.IncorrectFormat("You cannot use both `message_id` and `message_ids`!")
-
-    if custom_id and custom_ids:
-        raise error.IncorrectFormat("You cannot use both `custom_id` and `custom_ids`!")
-
-    if message_ids is None:
-        message_ids = [message_id]
+    message_ids = list(get_messages_ids(messages)) if messages is not None else [None]
+    custom_ids = list(get_components_ids(components)) if components is not None else [None]
 
     def wrapper(callback):
         nonlocal custom_ids
 
-        if custom_ids is None:
-            custom_ids = [callback.__name__] if use_callback_name else [custom_id]
+        if use_callback_name and custom_ids == [None]:
+            custom_ids = [callback.__name__]
 
         if message_ids == [None] and custom_ids == [None]:
-            raise error.IncorrectFormat(
-                "'message_ids' ('message_id') or 'custom_ids' ('custom_id') must be specified!"
-            )
+            raise error.IncorrectFormat("You must specify messages or components (or both)")
 
         return CogComponentCallbackObject(
             callback,

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -18,7 +18,7 @@ def cog_slash(
 ):
     """
     Decorator for Cog to add slash command.\n
-    Almost same as :func:`.client.SlashCommand.slash`.
+    Almost same as :meth:`.client.SlashCommand.slash`.
 
     Example:
 
@@ -88,7 +88,7 @@ def cog_subcommand(
 ):
     """
     Decorator for Cog to add subcommand.\n
-    Almost same as :func:`.client.SlashCommand.subcommand`.
+    Almost same as :meth:`.client.SlashCommand.subcommand`.
 
     Example:
 
@@ -173,6 +173,27 @@ def cog_component(
     use_callback_name=True,
     component_type: int = None,
 ):
+    """
+    Decorator for component callbacks in cogs.\n
+    Almost same as :meth:`.client.SlashCommand.component_callback`.
+
+    .. note::
+        ``message_id`` and ``message_ids`` cannot be used at the same time.
+
+    :param message_id: If specified, only interactions from the message given will be accepted.
+    :type message_id: Optional[int]
+    :param message_ids: Similar to ``message_id``, but accepts a list of message IDs instead.
+    :type message_ids: Optional[List[int]]
+    :param custom_id: The ``custom_id`` of the component. Defaults to the name of ``callback`` if ``use_callback_name=True``.
+    :type custom_id: Optional[str]
+    :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead.
+    :type custom_ids: Optional[List[str]]
+    :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
+    :type use_callback_name: bool
+    :param component_type: The type of the component. See :class:`.utils.manage_components.ComponentsType`.
+    :type component_type: Optional[int]
+    :raises: .error.IncorrectFormat
+    """
     if message_id and message_ids:
         raise error.IncorrectFormat("You cannot use both `message_id` and `message_ids`!")
 

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -191,7 +191,7 @@ def cog_component(
     :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
     If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
     :type use_callback_name: bool
-    :param component_type: The type of the component to avoid collisions with other component types. See :class:`.utils.manage_components.ComponentsType`.
+    :param component_type: The type of the component to avoid collisions with other component types. See :class:`.model.ComponentType`.
     :type component_type: Optional[int]
     :raises: .error.DuplicateCustomID, .error.IncorrectFormat
     """

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -188,8 +188,7 @@ def cog_component(
     :type custom_id: Optional[str]
     :param custom_ids: Similar to ``custom_ids``, but accepts a list of custom IDs instead. Empty list will mean that no interactions are accepted.
     :type custom_ids: Optional[List[str]]
-    :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified.
-    If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
+    :param use_callback_name: Whether the ``custom_id`` defaults to the name of ``callback`` if unspecified. If ``False``, either `message_ids`` (``message_id``) or ``custom_ids`` (``custom_id``) must be specified.
     :type use_callback_name: bool
     :param component_type: The type of the component to avoid collisions with other component types. See :class:`.model.ComponentType`.
     :type component_type: Optional[int]

--- a/discord_slash/error.py
+++ b/discord_slash/error.py
@@ -40,6 +40,14 @@ class DuplicateCommand(SlashCommandError):
         super().__init__(f"Duplicate command name detected: {name}")
 
 
+class DuplicateCustomID(SlashCommandError):
+    """
+    There is a duplicate component custom ID.
+    """
+    def __init__(self, custom_id: str):
+        super().__init__(f"Duplicate component custom ID detected: {custom_id}")
+
+
 class DuplicateSlashClient(SlashCommandError):
     """
     There are duplicate :class:`.SlashCommand` instances.

--- a/discord_slash/error.py
+++ b/discord_slash/error.py
@@ -40,12 +40,18 @@ class DuplicateCommand(SlashCommandError):
         super().__init__(f"Duplicate command name detected: {name}")
 
 
-class DuplicateCustomID(SlashCommandError):
+class DuplicateCallback(SlashCommandError):
     """
     There is a duplicate component custom ID.
     """
-    def __init__(self, custom_id: str):
-        super().__init__(f"Duplicate component custom ID detected: {custom_id}")
+
+    def __init__(self, message_id: int, custom_id: str, component_type: int):
+        super().__init__(
+            f"Duplicate component detected: "
+            f"message ID {message_id or '<any>'}, "
+            f"custom_id `{custom_id or '<any>'}`, "
+            f"component_type `{component_type or '<any>'}`"
+        )
 
 
 class DuplicateSlashClient(SlashCommandError):

--- a/discord_slash/error.py
+++ b/discord_slash/error.py
@@ -42,12 +42,12 @@ class DuplicateCommand(SlashCommandError):
 
 class DuplicateCallback(SlashCommandError):
     """
-    There is a duplicate component custom ID.
+    There is a duplicate component callback.
     """
 
     def __init__(self, message_id: int, custom_id: str, component_type: int):
         super().__init__(
-            f"Duplicate component detected: "
+            f"Duplicate component callback detected: "
             f"message ID {message_id or '<any>'}, "
             f"custom_id `{custom_id or '<any>'}`, "
             f"component_type `{component_type or '<any>'}`"

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -382,14 +382,14 @@ class CogSubcommandObject(SubcommandObject):
 
 class ComponentCallbackObject(CallbackObject):
     """
-    Internal component object.
+    Internal component object. Inherits :class:`CallbackObject`, so it has all variables from it.
 
     .. warning::
         Do not manually init this model.
 
-    :ivar custom_id: Custom ID of the component.
-    :ivar func: An optional single callback coroutine for the component. If the message ID given isn't in ``funcList``, this function will be ran instead.
-    :ivar funcList: An optional :class:`dict` with message IDs as keys and callback coroutines as values. If a message ID is found in the dict, the corresponding coroutine will be ran.
+    :ivar message_ids: The message IDs registered to this callback.
+    :ivar custom_ids: The component custom IDs registered to this callback.
+    :ivar component_type: Type of the component. See `:class.utils.manage_components.ComponentsType`
     """
 
     def __init__(
@@ -415,7 +415,7 @@ class ComponentCallbackObject(CallbackObject):
 
 class CogComponentCallbackObject(ComponentCallbackObject):
     """
-    Component callback object but for Cog.
+    Component callback object but for Cog. Has all variables from :class:`ComponentCallbackObject`.
 
     .. warning::
         Do not manually init this model.

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -87,7 +87,7 @@ class CommandData:
         id=None,
         application_id=None,
         version=None,
-        **kwargs
+        **kwargs,
     ):
         self.name = name
         self.description = description
@@ -405,7 +405,9 @@ class ComponentCallbackObject(CallbackObject):
         super().__init__(func)
         message_ids = set(message_ids)
         custom_ids = set(custom_ids)
-        self.keys = {(message_id, custom_id) for message_id in message_ids for custom_id in custom_ids}
+        self.keys = {
+            (message_id, custom_id) for message_id in message_ids for custom_id in custom_ids
+        }
 
         self.component_type = component_type
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -366,6 +366,37 @@ class CogSubcommandObject(SubcommandObject):
         self.cog = None  # Manually set this later.
 
 
+class ComponentCallbackObject:
+    """
+    Internal component object.
+
+    .. warning::
+        Do not manually init this model.
+
+    :ivar custom_id: Custom ID of the component.
+    :ivar func: An optional single callback coroutine for the component. If the message ID given isn't in ``funcList``, this function will be ran instead.
+    :ivar funcList: An optional :class:`dict` with message IDs as keys and callback coroutines as values. If a message ID is found in the dict, the corresponding coroutine will be ran.
+    """
+    def __init__(self, custom_id, func=None, funcList=None):
+        if funcList is None:
+            funcList = {}
+        self.custom_id = custom_id
+        self.func = func
+        self.funcList = funcList
+
+    async def invoke(self, ctx):
+        """
+        Invokes the component callback.
+
+        :param ctx: The :class:`.context.ComponentContext` for the interaction.
+        """
+        if self.funcList and self.funcList.get(ctx.origin_message_id):
+            coro = self.funcList.get(ctx.origin_message_id)
+            return await coro(ctx)
+        elif self.func:
+            return await self.func(ctx)
+
+
 class SlashCommandOptionType(IntEnum):
     """
     Equivalent of `ApplicationCommandOptionType <https://discord.com/developers/docs/interactions/slash-commands#applicationcommandoptiontype>`_  in the Discord API.

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -395,13 +395,18 @@ class ComponentCallbackObject(CallbackObject):
     def __init__(
         self,
         func,
-        message_ids=None,
-        custom_ids=None,
-        component_type=None,
+        message_ids,
+        custom_ids,
+        component_type,
     ):
+        if component_type not in (2, 3, None):
+            raise error.IncorrectFormat(f"Invalid component type `{component_type}`")
+
         super().__init__(func)
-        self.message_ids = message_ids or [None]
-        self.custom_ids = custom_ids or [None]
+        message_ids = set(message_ids)
+        custom_ids = set(custom_ids)
+        self.keys = {(message_id, custom_id) for message_id in message_ids for custom_id in custom_ids}
+
         self.component_type = component_type
 
     async def invoke(self, ctx):

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -152,9 +152,10 @@ def create_select(
 
 def get_components_ids(component: typing.Union[str, dict, list]) -> typing.Iterator[str]:
     """
-    Returns generator with 'custom_id' of component or components.
+    Returns generator with 'custom_id' of component or list of components.
 
     :param component: Custom ID or component dict (actionrow or button) or list of previous two.
+    :returns: typing.Iterator[str]
     """
 
     if isinstance(component, str):
@@ -174,13 +175,19 @@ def get_components_ids(component: typing.Union[str, dict, list]) -> typing.Itera
         )
 
 
-def _get_messages_ids(message: typing.Union[discord.Message, int, list]) -> typing.Iterator[int]:
+def get_messages_ids(message: typing.Union[int, discord.Message, list]) -> typing.Iterator[int]:
+    """
+    Returns generator with id of message or list messages.
+
+    :param message: message ID or message object or list of previous two.
+    :returns: typing.Iterator[int]
+    """
     if isinstance(message, int):
         yield message
     elif isinstance(message, discord.Message):
         yield message.id
     elif isinstance(message, list):
-        yield from (msg_id for msg in message for msg_id in _get_messages_ids(msg))
+        yield from (msg_id for msg in message for msg_id in get_messages_ids(msg))
     else:
         raise IncorrectType(
             f"Unknown component type of {message} ({type(message)}). "
@@ -190,8 +197,8 @@ def _get_messages_ids(message: typing.Union[discord.Message, int, list]) -> typi
 
 async def wait_for_component(
     client: discord.Client,
-    component: typing.Union[str, dict, list] = None,
-    message: typing.Union[discord.Message, int, list] = None,
+    messages: typing.Union[discord.Message, int, list] = None,
+    components: typing.Union[str, dict, list] = None,
     check=None,
     timeout=None,
 ) -> ComponentContext:
@@ -201,26 +208,27 @@ async def wait_for_component(
 
     :param client: The client/bot object.
     :type client: :class:`discord.Client`
-    :param component: Custom ID or component dict (actionrow or button) or list of previous two.
-    :param message: The message object to check for, or the message ID or list of previous two.
-    :type component: Union[dict, str]
+    :param messages: The message object to check for, or the message ID or list of previous two.
+    :type messages: Union[discord.Message, int, list]
+    :param components: Custom ID to check for, or component dict (actionrow or button) or list of previous two.
+    :type components: Union[str, dict, list]
     :param check: Optional check function. Must take a `ComponentContext` as the first parameter.
     :param timeout: The number of seconds to wait before timing out and raising :exc:`asyncio.TimeoutError`.
     :raises: :exc:`asyncio.TimeoutError`
     """
 
-    if not (component or message):
-        raise IncorrectFormat("You must specify component or message (or both)")
+    if not (messages or components):
+        raise IncorrectFormat("You must specify messages or components (or both)")
 
-    components_ids = list(get_components_ids(component)) if component else None
-    message_ids = list(_get_messages_ids(message)) if message else None
+    message_ids = list(get_messages_ids(messages)) if messages else None
+    custom_ids = list(get_components_ids(components)) if components else None
 
     def _check(ctx: ComponentContext):
         if check and not check(ctx):
             return False
-        # if components_ids is empty or there is a match
-        wanted_component = not components_ids or ctx.custom_id in components_ids
+        # if custom_ids is empty or there is a match
         wanted_message = not message_ids or ctx.origin_message_id in message_ids
-        return wanted_component and wanted_message
+        wanted_component = not custom_ids or ctx.custom_id in custom_ids
+        return wanted_message and wanted_component
 
     return await client.wait_for("component", check=_check, timeout=timeout)

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -26,6 +26,51 @@ def create_actionrow(*components: dict) -> dict:
     return {"type": ComponentType.actionrow, "components": components}
 
 
+def spread_to_rows(*components, max_in_row=5) -> typing.List[dict]:
+    """
+    Generates list of actionsrows from given components.
+
+    :param components: Components dicts (buttons or selects or existing actionrows) to spread. Use `None` to explicitly start a new row.
+    :type components: dict
+    :param max_in_row: Maximum number of elements in each row.
+    :type max_in_row: int
+    :return: list
+    """
+    if not components or len(components) > 25:
+        raise IncorrectFormat("Number of components should be between 1 and 25.")
+
+    if max_in_row < 1 or max_in_row > 5:
+        raise IncorrectFormat("max_in_row should be between 1 and 5.")
+
+    rows = []
+    button_row = []
+    for component in list(components) + [None]:
+        if component is not None and component["type"] is ComponentType.button:
+            button_row.append(component)
+
+            if len(button_row) == max_in_row:
+                rows.append(create_actionrow(*button_row))
+                button_row = []
+
+            continue
+
+        if button_row:
+            rows.append(create_actionrow(*button_row))
+            button_row = []
+
+        if component is None:
+            pass
+        elif component["type"] is ComponentType.actionrow:
+            rows.append(component)
+        elif component["type"] is ComponentType.select:
+            rows.append(create_actionrow(component))
+
+    if len(rows) > 5:
+        raise IncorrectFormat("Number of rows exceeds 5.")
+
+    return rows
+
+
 def emoji_to_dict(emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str]) -> dict:
     """
     Converts a default or custom emoji into a partial emoji dict.

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -27,3 +27,20 @@ These events can be registered to discord.py's listener or
     :param ctx: ComponentContext of the triggered component.
     :type ctx: :class:`.model.ComponentContext`
 
+.. function:: on_component_callback(ctx, callback)
+
+    Called when a component callback is triggered.
+
+    :param ctx: ComponentContext of the triggered component.
+    :type ctx: :class:`.model.ComponentContext`
+    :param callback: triggered ComponentCallbackObject
+    :type callback: :class:`.model.ComponentCallbackObject`
+
+.. function:: on_component_callback_error(ctx, ex)
+
+    Called when component callback had an exception while the callback was invoked.
+
+    :param ctx: Context of the callback.
+    :type ctx: :class:`.model.ComponentContext`
+    :param ex: Exception from the command invoke.
+    :type ex: Exception


### PR DESCRIPTION
## About this pull request

Added support of component callbacks!
Rewiews on naming of functions, classes and arguments will be very appreciated, as some of the current method names feel too long or ambigous.

## Changes
- Extracted everything not related to function of slash commands from `CommandObject` to new `CallbackObject` base class
- Added `ComponentCallbackObject` and `CogComponentCallbackObject` to hold component callback data (inherits from `CallbackObject`)
   - Thus, component callbacks support max_concurency, cooldowns, checks and individual error handlers (same as slash commands do now)
- Added methods to `SlashCommand` to add, remove and manage component callbacks
   - `add_component_callback` to registeer function as component callback
      -  Support of lists (including empty lists) of message and custom ids
      - `custom_id` defaults to function name in not specified
   - `extend_component_callback` to dynamically add combination of message_id and custom_id to existing callback object
   - `get_component_callback` to get component callback by message_id, custom_id, component_type
   - `remove_component_callback` to dynamically remove combination of message_id and custom_id from listening for callbacks
   - `remove_component_callback_obj`  to remove all listeners (combinations of message_id and custom_id) assosiated with specified callback object
- Added `component_callback` decorator to `SlashCommand` to register function as component callback
- Added `cog_component` decorator to `cog_ext`  to register cog method as component callback
- Added `on_component_callback` event triggered along with actual component callback
- Added component callback error handling event `on_component_callback_error` to work in same manner as slash commands do now

## Checklist

- [X] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [X] This adds something new.
- [X] There is/are breaking change(s).
- [X] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
