### PR TITLE
Simple fix in components

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -65,7 +65,7 @@ Next we'll go over the alternative, a global event handler. This works just the 
 
     @bot.event
     async def on_component(ctx: ComponentContext):
-        await button_ctx.edit_origin(content="You pressed a button!")
+        await ctx.edit_origin(content="You pressed a button!")
 
 But [writer], I dont want to edit the message
 *********************************************


### PR DESCRIPTION
## About this pull request

Changed `button_ctx` to `ctx`

## Changes

Changed `button_ctx` to `ctx`, beacuse `ctx` was defined and not `button_ctx`.

## Checklist

- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
