### PR TITLE
Remove positional arg support

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -1182,10 +1182,7 @@ class SlashCommand:
         :param args: Args. Can be list or dict.
         """
         try:
-            if isinstance(args, dict):
-                await func.invoke(ctx, **args)
-            else:
-                await func.invoke(ctx, *args)
+            await func.invoke(ctx, **args)
         except Exception as ex:
             if not await self._handle_invoke_error(func, ctx, ex):
                 await self.on_slash_command_error(ctx, ex)

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -2,6 +2,38 @@ Migration
 +++++++++
 This page contains instructions on how to migrate between versions with breaking changes.
 
+Migrate To V2.0.0
+=================
+This update introduced component support, and removed support for positional arguments.
+
+To resolve long standing issues with the library, we have removed positional argument support. From now on, only keyword arguments are supported. As such you may need to update your commands.
+
+Put simply, you will need to make sure your command parameters are named the same as your options, or use the connector argument.
+
+
+Example
+*******
+
+.. code-block:: python
+
+    # Example 1
+    @slash.slash(name="example_command", options=[
+        manage_commands.create_option(name="opt_one", [...]),
+        manage_commands.create_option(name="opt_two", [...])
+    ])
+    async def example_command(ctx, opt_one, opt_two):
+        await ctx.send(f"{opt_one=}, {opt_two=}")
+
+    # Example 2
+    @slash.slash(name="example_command", options=[
+        manage_commands.create_option(name="opt_one", [...]),
+        manage_commands.create_option(name="opt_two", [...])
+        ],
+        connector={"opt_one": "optone",
+                    "opt_two": "opttwo"})
+    async def example_command(ctx, optone, opttwo):
+        await ctx.send(f"{optone=}, {opttwo=}")
+
 Migrate To V1.1.0
 ==================
 Changes that you'll need to make in this version are mainly because of a new ui from discord, more info `here <https://github.com/discord/discord-api-docs/pull/2615>`_
@@ -24,7 +56,7 @@ We suggest deferring if you might take more than three seconds to respond, but i
     ``ctx.channel.send`` does **not** count as responding.
 
 Example
---------
+*******
 
 .. code-block:: python
 


### PR DESCRIPTION
## About this pull request

Removes positional arg support as per vote

## Changes

- Removed positional arg support
- Added migration documentation

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [x] There is/are breaking change(s).
- [x] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
