### PR TITLE
Added OptionType

### DIFF
--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -247,7 +247,17 @@ async def update_guild_commands_permissions(bot_id,
                 raise RequestFailure(resp.status, await resp.text())
             return await resp.json()
 
-
+class OptionType():
+    subcommand = 1
+    subcommandgroup = 2
+    string = 3
+    integer = 4
+    boolean = 5
+    user = 6
+    channel = 7
+    role = 8
+    mentionable = 9
+          
 def create_option(name: str,
                   description: str,
                   option_type: typing.Union[int, type],


### PR DESCRIPTION
## About this pull request

Adds OptionType class

## Changes

Added OptionType class, so you can use for example: `option_type=OptionType.string` instead of `option_type=3`

## Checklist

- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
