### PR TITLE
Compinent callback docs, small fix

### DIFF
--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -82,6 +82,8 @@ def emoji_to_dict(emoji: typing.Union[discord.Emoji, discord.PartialEmoji, str])
     """
     if isinstance(emoji, discord.Emoji):
         emoji = {"name": emoji.name, "id": emoji.id, "animated": emoji.animated}
+    elif isinstance(emoji, discord.PartialEmoji):
+        emoji = emoji.to_dict()
     elif isinstance(emoji, str):
         emoji = {"name": emoji, "id": None}
     return emoji if emoji else {}

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -51,7 +51,7 @@ Wait_for
 ********
 
 Lets go through the most common method first, responding in the command itself. We simply need to :func:`wait_for` the event, just like you do for reactions. For this we're going to use :func:`wait_for_component() <discord_slash.utils.manage_components>`, and we're going to only wait for events from the action row we just sent.
-This method will return a :class:`ComponentContext <discord_slash.context.ComponentContext>` object that we can use to respond. For this example, we'll just edit the original message (:meth:`edit_origin() <discord_slash.context.ComponentContext.edit_origin>`)
+This method will return a :class:`ComponentContext <discord_slash.context.ComponentContext>` object that we can use to respond. For this example, we'll just edit the original message (:meth:`edit_origin() <discord_slash.context.ComponentContext.edit_origin>`, uses same logic as :func:`edit()`)
 
 .. code-block:: python
 
@@ -88,7 +88,7 @@ Let's register our callback function via decorator :meth:`component_callback() <
 
 In this example, :func:`hello` will be triggered when you receive interaction event from a component with a `custom_id` set to `"hello"`. Just like slash commands, The callback's `custom_id` defaults to the function name.
 You can also register such callbacks in cogs using :func:`cog_component() <discord_slash.cog_ext>`
-Additionally, component callbacks can be dynamically added (:meth:`add_component_callback() <discord_slash.client.SlashCommand.add_component_callback>`), removed (:meth:`remove_component_callback_obj() <discord_slash.client.SlashCommand.remove_component_callback_obj>`) or edited (:meth:`remove_component_callback() <discord_slash.client.SlashCommand.remove_component_callback>`, :meth:`extend_component_callback() <discord_slash.client.SlashCommand.extend_component_callback>`)
+Additionally, component callbacks can be dynamically added, removed or edited - see :class:`SlashCommand <discord_slash.client.SlashCommand>`
 
 But [writer], I dont want to edit the message
 *********************************************

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -45,9 +45,9 @@ Well, in Discord, clicking buttons and using slash commands are called ``interac
 Responding to interactions
 __________________________
 
-When responding, you have 3 choices in how you handle interactions. You can either wait for them in the command itself, or listen for them in a global event handler (similar to :func:`on_slash_command_error`), or register async function as callback callback.
+When responding, you have 3 choices in how you handle interactions. You can either wait for them in the command itself, or listen for them in a global event handler (similar to :func:`on_slash_command_error`), or register async function as component callback.
 
-Lets go through the most common method first, responding in the event itself. We simply need to :func:`wait_for` the event, just like you do for reactions. For this we're going to use :func:`wait_for_component() <discord_slash.utils.manage_components>`, and we're going to only wait for events from the action row we just sent.
+Lets go through the most common method first, responding in the command itself. We simply need to :func:`wait_for` the event, just like you do for reactions. For this we're going to use :func:`wait_for_component() <discord_slash.utils.manage_components>`, and we're going to only wait for events from the action row we just sent.
 This method will return a :class:`ComponentContext <discord_slash.context.ComponentContext>` object that we can use to respond. For this example, we'll just edit the original message (:meth:`edit_origin() <discord_slash.context.ComponentContext.edit_origin>`)
 
 .. code-block:: python
@@ -70,13 +70,14 @@ Next we'll go over the alternative, a global event handler. This works just the 
 
 There is one more method - making a function that'll be component callback - triggered when components in specified messages or with specified custom_ids would be activated
 Let's register our callback function via decorator :meth:`component_callback() <discord_slash.client.SlashCommand.component_callback>`, in similar ways to slash commands.
+
 .. code-block:: python
 
     @slash.component_callback()
     async def hello(button_context: ComponentContext):
         await ctx.edit_origin(content="You pressed a button!")
 
-In this example, :func:`hello` will be triggered when you receive interaction from component `custom_id` `"hello"`. Just like slash commands, `custom_id` of the callback defaults to the function name.
+In this example, :func:`hello` will be triggered when you receive interaction event from a component with a `custom_id` set to `"hello"`. Just like slash commands, The callback's `custom_id` defaults to the function name.
 You can also register such callbacks in cogs using :func:`cog_component() <discord_slash.cog_ext>`
 Additionally, component callbacks can be dynamically added (:meth:`add_component_callback() <discord_slash.client.SlashCommand.add_component_callback>`), removed (:meth:`remove_component_callback_obj() <discord_slash.client.SlashCommand.remove_component_callback_obj>`) or edited (:meth:`remove_component_callback() <discord_slash.client.SlashCommand.remove_component_callback>`, :meth:`extend_component_callback() <discord_slash.client.SlashCommand.extend_component_callback>`)
 

--- a/docs/components.rst
+++ b/docs/components.rst
@@ -47,6 +47,9 @@ __________________________
 
 When responding, you have 3 choices in how you handle interactions. You can either wait for them in the command itself, or listen for them in a global event handler (similar to :func:`on_slash_command_error`), or register async function as component callback.
 
+Wait_for
+********
+
 Lets go through the most common method first, responding in the command itself. We simply need to :func:`wait_for` the event, just like you do for reactions. For this we're going to use :func:`wait_for_component() <discord_slash.utils.manage_components>`, and we're going to only wait for events from the action row we just sent.
 This method will return a :class:`ComponentContext <discord_slash.context.ComponentContext>` object that we can use to respond. For this example, we'll just edit the original message (:meth:`edit_origin() <discord_slash.context.ComponentContext.edit_origin>`)
 
@@ -59,6 +62,9 @@ This method will return a :class:`ComponentContext <discord_slash.context.Compon
 
 .. note:: It's worth being aware that if you handle the event in the command itself, it will not persist reboots. As such when you restart the bot, the interaction will fail
 
+Global event handler
+********************
+
 Next we'll go over the alternative, a global event handler. This works just the same as :func:`on_slash_command_error` or `on_ready`. But note that this code will be triggered on any components interaction.
 
 .. code-block:: python
@@ -67,6 +73,9 @@ Next we'll go over the alternative, a global event handler. This works just the 
     async def on_component(ctx: ComponentContext):
         # you may want to filter or change behaviour based on custom_id or message
         await ctx.edit_origin(content="You pressed a button!")
+
+Component callbacks
+********************
 
 There is one more method - making a function that'll be component callback - triggered when components in specified messages or with specified custom_ids would be activated
 Let's register our callback function via decorator :meth:`component_callback() <discord_slash.client.SlashCommand.component_callback>`, in similar ways to slash commands.


### PR DESCRIPTION
## About this pull request

Added compinent callback docs, patched up some other stuff in compinent docs, fixed usage of PartialEmoji in buttons
## Changes

What changes were made?

- Added compinent callback docs
- Patched up some other stuff in compinent docs
- Fixed usage of PartialEmoji in buttons

## Checklist

- [X] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
