### PR TITLE
Simplify components.rst

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -9,15 +9,17 @@ First lets cover the basics. Discord messages can have *components*, such as but
 Sending some components
 _______________________
 
+.. note:: This will work in both slash commands, and discord.py commands
+
 First we need to create some buttons, lets put them in a list for now. We'll use :meth:`create_button() <discord_slash.utils.manage_components>` to create a green button
 
 .. code-block:: python
 
-    from discord_slash.utils import manage_components
+    from discord_slash.utils.manage_components import create_button, create_actionrow
     from discord_slash.model import ButtonStyle
 
     buttons = [
-                manage_components.create_button(
+                create_button(
                     style=ButtonStyle.green,
                     label="A Green Button"
                 ),
@@ -27,8 +29,7 @@ So we have a button, but where do we use it. Let's create an action row with :fu
 
 .. code-block:: python
 
-    [...]
-    action_row = manage_components.create_actionrow(*buttons)
+    action_row = create_actionrow(*buttons)
 
 
 Fantastic, we now have an action row with a green button in it, now lets get it sent in discord
@@ -37,7 +38,18 @@ Fantastic, we now have an action row with a green button in it, now lets get it 
 
     await ctx.send("My Message", components=[action_row])
 
-.. note:: This will work in both slash commands, and discord.py commands
+
+And to bring it all together, you could use this:
+
+.. code-block:: python
+
+    from discord_slash.utils.manage_components import create_button, create_actionrow
+    from discord_slash.model import ButtonStyle
+
+    await ctx.send("My Message", components=[
+                                        create_actionrow(
+                                            create_button(style=ButtonStyle.green, label="A Green Button"))
+                                        ])
 
 Now if you've followed along, you have a green button in discord! But theres a problem, whenever you click it you see that the ``interaction failed``. Why is that?
 Well, in Discord, clicking buttons and using slash commands are called ``interactions``, and Discord doesn't know if we've received them or not unless we tell Discord. So how do we do that?
@@ -55,9 +67,11 @@ This method will return a :class:`ComponentContext <discord_slash.context.Compon
 
 .. code-block:: python
 
+    from discord_slash.utils.manage_components import wait_for_component
+
     await ctx.send("My Message", components=[action_row])
     # note: this will only catch one button press, if you want more, put this in a loop
-    button_ctx: ComponentContext = await manage_components.wait_for_component(bot, components=action_row)
+    button_ctx: ComponentContext = await wait_for_component(bot, components=action_row)
     await button_ctx.edit_origin(content="You pressed a button!")
 
 .. note:: It's worth being aware that if you handle the event in the command itself, it will not persist reboots. As such when you restart the bot, the interaction will fail
@@ -77,7 +91,7 @@ Next we'll go over the alternative, a global event handler. This works just the 
 Component callbacks
 ********************
 
-There is one more method - making a function that'll be component callback - triggered when components in specified messages or with specified custom_ids would be activated
+There is one more method - making a function that'll be component callback - triggered when components in a specified message or specific ``custom_id`` are used.
 Let's register our callback function via decorator :meth:`component_callback() <discord_slash.client.SlashCommand.component_callback>`, in similar ways to slash commands.
 
 .. code-block:: python


### PR DESCRIPTION
## About this pull request

Simplifies some of the examples in components.rst as people were getting confused by all the `manage_commands.abc` calls

## Changes

- See above
- Reword of some lines
- Add a button example code sample

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
