### PR TITLE
Fix Discord.py 2.0's CooldownMapping

### DIFF
--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -5,7 +5,7 @@ from enum import IntEnum
 from inspect import iscoroutinefunction
 
 import discord
-from discord.ext.commands import CommandOnCooldown, CooldownMapping, BucketType
+from discord.ext.commands import BucketType, CommandOnCooldown, CooldownMapping
 
 from . import error, http
 from .dpy_overrides import ComponentMessage

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -5,7 +5,7 @@ from enum import IntEnum
 from inspect import iscoroutinefunction
 
 import discord
-from discord.ext.commands import CommandOnCooldown, CooldownMapping
+from discord.ext.commands import CommandOnCooldown, CooldownMapping, BucketType
 
 from . import error, http
 from .dpy_overrides import ComponentMessage
@@ -138,7 +138,10 @@ class CallbackObject:
         cooldown = None
         if hasattr(self.func, "__commands_cooldown__"):
             cooldown = self.func.__commands_cooldown__
-        self._buckets = CooldownMapping(cooldown)
+        try:
+            self._buckets = CooldownMapping(cooldown)
+        except TypeError:
+            self._buckets = CooldownMapping(cooldown, BucketType.default)
 
         self._max_concurrency = None
         if hasattr(self.func, "__commands_max_concurrency__"):


### PR DESCRIPTION
## About this pull request

Due to how Discord py 2.0 changed CooldownMapping, it now requires type as second argument in order to work

## Changes

Added a try catch which in case it's the master branch, then it proceeds to load the default BucketType

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
