### PR TITLE
Fix spelling mistakes in components.rst

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -86,7 +86,7 @@ Let's register our callback function via decorator :meth:`component_callback() <
     async def hello(button_context: ComponentContext):
         await ctx.edit_origin(content="You pressed a button!")
 
-In this example, :func:`hello` will be triggered when you receive interaction event from a component with a `custom_id` set to `"hello"`. Just like slash commands, The callback's `custom_id` defaults to the function name.
+In this example, :func:`hello` will be triggered when you receive interaction event from a component with a `custom_id` set to `"hello"`. Just like slash commands, the callback's `custom_id` defaults to the function name.
 You can also register such callbacks in cogs using :func:`cog_component() <discord_slash.cog_ext>`
 Additionally, component callbacks can be dynamically added, removed or edited - see :class:`SlashCommand <discord_slash.client.SlashCommand>`
 
@@ -95,7 +95,7 @@ But [writer], I dont want to edit the message
 
 Well lucky for you, you don't have to. You can either respond silently, with a thinking animation, or send a whole new message. Take a look here: :class:`ComponentContext <discord_slash.context.ComponentContext>`
 
-How do i know which button was pressed?
+How do I know which button was pressed?
 _______________________________________
 
 Each button gets a ``custom_id`` (which is always a string), this is a unique identifier of which button is being pressed. You can specify what the ID is when you define your button, if you don't; a random one will be generated. When handling the event, simply check the custom_id, and handle accordingly.


### PR DESCRIPTION
## About this pull request

Fix spelling mistakes in components.rst

## Changes

There were some spelling mistakes, such as an "i" instead of "I" in "How do i know which button was pressed?" and "T" instead of "t" in "Just like slash commands, The callback's `custom_id` defaults to the function name."

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
