### PR TITLE
Fix improper usage of `is`

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -535,8 +535,7 @@ class SlashCommand:
         """
         name = name or cmd.__name__
         name = name.lower()
-        guild_ids = guild_ids if guild_ids else []
-        if not all(isinstance(item, int) for item in guild_ids) and guild_ids is not []:
+        if not all(isinstance(item, int) for item in guild_ids):
             raise error.IncorrectGuildIDType(
                 f"The snowflake IDs {guild_ids} given are not a list of integers. Because of discord.py convention, please use integer IDs instead. Furthermore, the command '{name}' will be deactivated and broken until fixed."
             )
@@ -617,8 +616,7 @@ class SlashCommand:
         name = name or cmd.__name__
         name = name.lower()
         description = description or getdoc(cmd)
-        guild_ids = guild_ids if guild_ids else []
-        if not all(isinstance(item, int) for item in guild_ids) and guild_ids is not []:
+        if guild_ids and not all(isinstance(item, int) for item in guild_ids):
             raise error.IncorrectGuildIDType(
                 f"The snowflake IDs {guild_ids} given are not a list of integers. Because of discord.py convention, please use integer IDs instead. Furthermore, the command '{name}' will be deactivated and broken until fixed."
             )

--- a/discord_slash/dpy_overrides.py
+++ b/discord_slash/dpy_overrides.py
@@ -28,7 +28,7 @@ class ComponentMessage(discord.Message):
 
 
 def new_override(cls, *args, **kwargs):
-    if cls is discord.Message:
+    if isinstance(cls, discord.Message):
         return object.__new__(ComponentMessage)
     else:
         return object.__new__(cls)

--- a/discord_slash/dpy_overrides.py
+++ b/discord_slash/dpy_overrides.py
@@ -23,7 +23,7 @@ class ComponentMessage(discord.Message):
         """
         for row in self.components:
             for component in row["components"]:
-                if component["custom_id"] is custom_id:
+                if component["custom_id"] == custom_id:
                     return component
 
 

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -47,7 +47,7 @@ def spread_to_rows(*components, max_in_row=5) -> typing.List[dict]:
     rows = []
     button_row = []
     for component in list(components) + [None]:
-        if component is not None and component["type"] is ComponentType.button:
+        if component is not None and component["type"] == ComponentType.button:
             button_row.append(component)
 
             if len(button_row) == max_in_row:
@@ -62,9 +62,9 @@ def spread_to_rows(*components, max_in_row=5) -> typing.List[dict]:
 
         if component is None:
             pass
-        elif component["type"] is ComponentType.actionrow:
+        elif component["type"] == ComponentType.actionrow:
             rows.append(component)
-        elif component["type"] is ComponentType.select:
+        elif component["type"] == ComponentType.select:
             rows.append(create_actionrow(component))
 
     if len(rows) > 5:


### PR DESCRIPTION
## About this pull request

This fixes improper usages of the `is` and `is not` operators. This is only used when you want to check if the ids between two objects are the same. This should never be used for value equality. In practice this is rarely needed and is usually only used when checking if a variable is `None`.

## Changes

- Replace `is` comparison for checking value equality with `==`
- Consolidated if statements where `is not` is used
- Replace `is` type checking with `isinstance`

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
