### PR TITLE
Make edit functions more like discord.py edit functions

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -408,7 +408,7 @@ class ComponentContext(InteractionContext):
         except KeyError:
             pass
         else:
-            if 'embeds' in payload:
+            if 'embeds' in _resp:
                 raise error.IncorrectFormat('Cannot mix embed and embeds keyword arguments')
 
             if embed is None:

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -373,45 +373,57 @@ class ComponentContext(InteractionContext):
         """
         _resp = {}
 
-        content = fields.get("content")
-        if content is not None:
-            _resp["content"] = str(content)
-
-        file = fields.get("file")
-        files = fields.get("files")
-        components = fields.get("components")
-
-        if components is not None:
-            _resp["components"] = components
-
-        if files is not None and file is not None:
-            raise error.IncorrectFormat("You can't use both `file` and `files`!")
-        if file:
-            files = [file]
-            
-         # Check if the embeds interface is being used
         try:
-            embeds = fields['embeds']
+            content = fields["content"]
+        except KeyError:
+            pass
+        else:
+            if content is not None:
+                content = str(content)
+            _resp["content"] = content
+
+        try:
+            components = fields["components"]
+        except KeyError:
+            pass
+        else:
+            if components is None:
+                _resp["components"] = []
+            else:
+                _resp["components"] = components
+
+        try:
+            embeds = fields["embeds"]
         except KeyError:
             # Nope
             pass
         else:
+            if not isinstance(embeds, list):
+                raise error.IncorrectFormat("Provide a list of embeds.")
             if embeds is None or len(embeds) > 10:
-                raise error.IncorrectFormat('embeds has a maximum of 10 elements')
+                raise error.IncorrectFormat("Do not provide more than 10 embeds.")
             _resp["embeds"] = [e.to_dict() for e in embeds]
 
         try:
-            embed = fields['embed']
+            embed = fields["embed"]
         except KeyError:
             pass
         else:
-            if 'embeds' in _resp:
-                raise error.IncorrectFormat('Cannot mix embed and embeds keyword arguments')
+            if "embeds" in _resp:
+                raise error.IncorrectFormat("You can't use both `embed` and `embeds`!")
 
             if embed is None:
                 _resp["embeds"] = []
             else:
                 _resp["embeds"] = [embed.to_dict()]
+
+        file = fields.get("file")
+        files = fields.get("files")
+
+        if files is not None and file is not None:
+            raise error.IncorrectFormat("You can't use both `file` and `files`!")
+        if file:
+            files = [file]
 
         allowed_mentions = fields.get("allowed_mentions")
         _resp["allowed_mentions"] = (

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -374,7 +374,7 @@ class ComponentContext(InteractionContext):
         _resp = {}
 
         content = fields.get("content")
-        if content:
+        if content is not None:
             _resp["content"] = str(content)
 
         file = fields.get("file")
@@ -388,9 +388,6 @@ class ComponentContext(InteractionContext):
             raise error.IncorrectFormat("You can't use both `file` and `files`!")
         if file:
             files = [file]
-        if embed:
-            embeds = [embed]
-            
             
          # Check if the embeds interface is being used
         try:

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -400,7 +400,7 @@ class ComponentContext(InteractionContext):
         else:
             if not isinstance(embeds, list):
                 raise error.IncorrectFormat("Provide a list of embeds.")
-            if embeds is None or len(embeds) > 10:
+            if len(embeds) > 10:
                 raise error.IncorrectFormat("Do not provide more than 10 embeds.")
             _resp["embeds"] = [e.to_dict() for e in embeds]
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -495,33 +495,57 @@ class SlashMessage(ComponentMessage):
         """
         _resp = {}
 
-        content = fields.get("content")
-        if content:
-            _resp["content"] = str(content)
+        try:
+            content = fields["content"]
+        except KeyError:
+            pass
+        else:
+            if content is not None:
+                content = str(content)
+            _resp["content"] = content
 
-        embed = fields.get("embed")
-        embeds = fields.get("embeds")
+        try:
+            components = fields["components"]
+        except KeyError:
+            pass
+        else:
+            if components is None:
+                _resp["components"] = []
+            else:
+                _resp["components"] = components
+
+        try:
+            embeds = fields["embeds"]
+        except KeyError:
+            # Nope
+            pass
+        else:
+            if not isinstance(embeds, list):
+                raise error.IncorrectFormat("Provide a list of embeds.")
+            if embeds is None or len(embeds) > 10:
+                raise error.IncorrectFormat("Do not provide more than 10 embeds.")
+            _resp["embeds"] = [e.to_dict() for e in embeds]
+
+        try:
+            embed = fields["embed"]
+        except KeyError:
+            pass
+        else:
+            if "embeds" in _resp:
+                raise error.IncorrectFormat("You can't use both `embed` and `embeds`!")
+
+            if embed is None:
+                _resp["embeds"] = []
+            else:
+                _resp["embeds"] = [embed.to_dict()]
+
         file = fields.get("file")
         files = fields.get("files")
-        components = fields.get("components")
 
-        if components:
-            _resp["components"] = components
-
-        if embed and embeds:
-            raise error.IncorrectFormat("You can't use both `embed` and `embeds`!")
-        if file and files:
+        if files is not None and file is not None:
             raise error.IncorrectFormat("You can't use both `file` and `files`!")
         if file:
             files = [file]
-        if embed:
-            embeds = [embed]
-        if embeds:
-            if not isinstance(embeds, list):
-                raise error.IncorrectFormat("Provide a list of embeds.")
-            elif len(embeds) > 10:
-                raise error.IncorrectFormat("Do not provide more than 10 embeds.")
-            _resp["embeds"] = [x.to_dict() for x in embeds]
 
         allowed_mentions = fields.get("allowed_mentions")
         _resp["allowed_mentions"] = (

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -522,7 +522,7 @@ class SlashMessage(ComponentMessage):
         else:
             if not isinstance(embeds, list):
                 raise error.IncorrectFormat("Provide a list of embeds.")
-            if embeds is None or len(embeds) > 10:
+            if len(embeds) > 10:
                 raise error.IncorrectFormat("Do not provide more than 10 embeds.")
             _resp["embeds"] = [e.to_dict() for e in embeds]
 


### PR DESCRIPTION
## About this pull request

In short, the current system for the edit function has a number of flaws, like not allowing empty lists to be passed to components and not allowing `None` values to be passed to `content`.

This PR attempts to fix that by making it more similar to discord.py's current system for edits, which can more accurately detect which type of changes someone may want.

This also fixes #228.

(NOTE: this is my first major PR. I might have messed up something. Also you might argue that this might be breaking, but not by much. Please do give feedback regardless.)

## Changes

Pretty much all changes were made exclusively to `ComponentContext.edit_origin` and `SlashMessage._slash_edit`. You can see the changes for yourself, but they've been changed to be handled more or less like how `discord.py` handles edits in 1.X (if it changed in 2.0 I wouldn't know). 

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #228 
- [ ] This adds something new.
- [x] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
