### PR TITLE
Make allowed_mentions more like discord.py

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -411,7 +411,9 @@ class ComponentContext(InteractionContext):
         allowed_mentions = fields.get("allowed_mentions")
         if allowed_mentions is not None:
             if self.bot.allowed_mentions is not None:
-                _resp["allowed_mentions"] = self.bot.allowed_mentions.merge(allowed_mentions).to_dict()
+                _resp["allowed_mentions"] = self.bot.allowed_mentions.merge(
+                    allowed_mentions
+                ).to_dict()
             else:
                 _resp["allowed_mentions"] = allowed_mentions.to_dict()
         else:

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -188,15 +188,22 @@ class InteractionContext:
                 "The top level of the components list must be made of ActionRows!"
             )
 
+        if allowed_mentions is not None:
+            if self.bot.allowed_mentions is not None:
+                allowed_mentions = self.bot.allowed_mentions.merge(allowed_mentions).to_dict()
+            else:
+                allowed_mentions = allowed_mentions.to_dict()
+        else:
+            if self.bot.allowed_mentions is not None:
+                allowed_mentions = self.bot.allowed_mentions.to_dict()
+            else:
+                allowed_mentions = {}
+
         base = {
             "content": content,
             "tts": tts,
             "embeds": [x.to_dict() for x in embeds] if embeds else [],
-            "allowed_mentions": allowed_mentions.to_dict()
-            if allowed_mentions
-            else self.bot.allowed_mentions.to_dict()
-            if self.bot.allowed_mentions
-            else {},
+            "allowed_mentions": allowed_mentions,
             "components": components or [],
         }
         if hidden:
@@ -402,13 +409,16 @@ class ComponentContext(InteractionContext):
             _resp["embeds"] = [x.to_dict() for x in embeds]
 
         allowed_mentions = fields.get("allowed_mentions")
-        _resp["allowed_mentions"] = (
-            allowed_mentions.to_dict()
-            if allowed_mentions
-            else self.bot.allowed_mentions.to_dict()
-            if self.bot.allowed_mentions
-            else {}
-        )
+        if allowed_mentions is not None:
+            if self.bot.allowed_mentions is not None:
+                _resp["allowed_mentions"] = self.bot.allowed_mentions.merge(allowed_mentions).to_dict()
+            else:
+                _resp["allowed_mentions"] = allowed_mentions.to_dict()
+        else:
+            if self.bot.allowed_mentions is not None:
+                _resp["allowed_mentions"] = self.bot.allowed_mentions.to_dict()
+            else:
+                _resp["allowed_mentions"] = {}
 
         if not self.responded:
             if files and not self.deferred:

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -524,13 +524,16 @@ class SlashMessage(ComponentMessage):
             _resp["embeds"] = [x.to_dict() for x in embeds]
 
         allowed_mentions = fields.get("allowed_mentions")
-        _resp["allowed_mentions"] = (
-            allowed_mentions.to_dict()
-            if allowed_mentions
-            else self._state.allowed_mentions.to_dict()
-            if self._state.allowed_mentions
-            else {}
-        )
+        if allowed_mentions is not None:
+            if self.bot.allowed_mentions is not None:
+                _resp["allowed_mentions"] = self.bot.allowed_mentions.merge(allowed_mentions).to_dict()
+            else:
+                _resp["allowed_mentions"] = allowed_mentions.to_dict()
+        else:
+            if self.bot.allowed_mentions is not None:
+                _resp["allowed_mentions"] = self.bot.allowed_mentions.to_dict()
+            else:
+                _resp["allowed_mentions"] = {}
 
         await self._http.edit(_resp, self.__interaction_token, self.id, files=files)
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -526,7 +526,9 @@ class SlashMessage(ComponentMessage):
         allowed_mentions = fields.get("allowed_mentions")
         if allowed_mentions is not None:
             if self.bot.allowed_mentions is not None:
-                _resp["allowed_mentions"] = self.bot.allowed_mentions.merge(allowed_mentions).to_dict()
+                _resp["allowed_mentions"] = self.bot.allowed_mentions.merge(
+                    allowed_mentions
+                ).to_dict()
             else:
                 _resp["allowed_mentions"] = allowed_mentions.to_dict()
         else:


### PR DESCRIPTION
## About this pull request

`allowed_mentions` (in this library) currently uses only the passed-through `allowed_mentions` if it exists in the kwargs of the functions it is in, This is unlike discord.py, which simply merges the `allowed_mentions` with the bot's `allowed_mentions`. This PR attempts to fix that. 

Fixes #229. Also, technically a breaking change, but barely.

## Changes

Changes to `InteractionMessage.send`, `ComponentContext.edit_origin`, and `SlashMessage._slash_edit` were made in order to facilitate this. The changes should be simple enough.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #229
- [ ] This adds something new.
- [x] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
