### PR TITLE
Fix example in 'Component callbacks' section

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -83,7 +83,7 @@ Let's register our callback function via decorator :meth:`component_callback() <
 .. code-block:: python
 
     @slash.component_callback()
-    async def hello(button_context: ComponentContext):
+    async def hello(ctx: ComponentContext):
         await ctx.edit_origin(content="You pressed a button!")
 
 In this example, :func:`hello` will be triggered when you receive interaction event from a component with a `custom_id` set to `"hello"`. Just like slash commands, the callback's `custom_id` defaults to the function name.


### PR DESCRIPTION
## About this pull request

Fix example in 'Component callbacks' section

## Changes

The function in the example had a parameter called button_context, but ctx was used instead inside the defined function, so I replaced button_context with ctx.

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
