### PR TITLE
Fix None-Type error in `wait_for_component`

### DIFF
--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -302,7 +302,7 @@ async def wait_for_component(
     custom_ids = list(get_components_ids(components)) if components else None
 
     # automatically convert improper custom_ids
-    if not all(isinstance(x, str) for x in custom_ids):
+    if custom_ids and not all(isinstance(x, str) for x in custom_ids):
         custom_ids = [str(i) for i in custom_ids]
         logger.warning(
             "Custom_ids have been automatically converted to a list of strings. Please use lists of strings in future.\n"


### PR DESCRIPTION
## About this pull request

Adds a None check to `wait_for_component`

## Changes

See Above

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
