### PR TITLE
Fix bug on `update_single_command_permissions`

### DIFF
--- a/discord_slash/utils/manage_commands.py
+++ b/discord_slash/utils/manage_commands.py
@@ -184,7 +184,7 @@ async def update_single_command_permissions(bot_id, bot_token, guild_id, command
     url = f"https://discord.com/api/v8/applications/{bot_id}/guilds/{guild_id}/commands/{command_id}/permissions"
     async with aiohttp.ClientSession() as session:
         async with session.put(
-            url, headers={"Authorization": f"Bot {bot_token}"}, json=permissions
+            url, headers={"Authorization": f"Bot {bot_token}"}, json={"permissions": permissions}
         ) as resp:
             if resp.status == 429:
                 _json = await resp.json()

--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -212,7 +212,7 @@ def create_select(
     :param placeholder: Custom placeholder text if nothing is selected
     :param min_values: The minimum number of items that **must** be chosen
     :param max_values: The maximum number of items that **can** be chosen
-    :param disabled: Disables this component. Defaults to ``False``. 
+    :param disabled: Disables this component. Defaults to ``False``.
     """
     if not len(options) or len(options) > 25:
         raise IncorrectFormat("Options length should be between 1 and 25.")


### PR DESCRIPTION
## About this pull request

Fix bug from`discord_slash.utils.manage_commands.update_single_command_permissions`

From [discord docs](https://discord.com/developers/docs/interactions/slash-commands#edit-application-command-permissions-json-params), to change the permission of a slash command, it require a dict not just a list of permission

## Changes

Change the request from a list of permission to a dictionary of a list of permission

## Checklist

- [ x ] I've run the `pre_push.py` script to format and lint code.
- [ x ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
