### PR TITLE
Fix for allowed_mentions for SlashMessage._slash_edit

### DIFF
--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -549,15 +549,15 @@ class SlashMessage(ComponentMessage):
 
         allowed_mentions = fields.get("allowed_mentions")
         if allowed_mentions is not None:
-            if self.bot.allowed_mentions is not None:
-                _resp["allowed_mentions"] = self.bot.allowed_mentions.merge(
+            if self._state.allowed_mentions is not None:
+                _resp["allowed_mentions"] = self._state.allowed_mentions.merge(
                     allowed_mentions
                 ).to_dict()
             else:
                 _resp["allowed_mentions"] = allowed_mentions.to_dict()
         else:
-            if self.bot.allowed_mentions is not None:
-                _resp["allowed_mentions"] = self.bot.allowed_mentions.to_dict()
+            if self._state.allowed_mentions is not None:
+                _resp["allowed_mentions"] = self._state.allowed_mentions.to_dict()
             else:
                 _resp["allowed_mentions"] = {}
 


### PR DESCRIPTION
## About this pull request

More or less fixes the problem with #251. That's all, really.

## Changes

Simple fixes with `SlashMessage._slash_edit` to rely on `_state` instead of a non-existent `bot`.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #251 
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
