### PR TITLE
Make `sync_all_commands` errors easier to understand

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -431,10 +431,8 @@ class SlashCommand:
                             )
 
                         ex.args = (error_string,)
-                        raise ex
 
-                    else:
-                        raise ex
+                    raise ex
             else:
                 self.logger.debug(
                     f"Detected no changes on {scope if scope is not None else 'global'}, skipping"

--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import re
 import typing
 from contextlib import suppress
 from inspect import getdoc, iscoroutinefunction
@@ -410,9 +411,30 @@ class SlashCommand:
                 self.logger.debug(
                     f"Detected changes on {scope if scope is not None else 'global'}, updating them"
                 )
-                existing_cmds = await self.req.put_slash_commands(
-                    slash_commands=to_send, guild_id=scope
-                )
+                try:
+                    existing_cmds = await self.req.put_slash_commands(
+                        slash_commands=to_send, guild_id=scope
+                    )
+                except discord.HTTPException as ex:
+                    if ex.status == 400:
+                        # catch bad requests
+                        cmd_nums = set(
+                            re.findall(r"In\s(\d).", ex.args[0])
+                        )  # find all discords references to commands
+                        error_string = ex.args[0]
+
+                        for num in cmd_nums:
+                            error_command = to_send[int(num)]
+                            error_string = error_string.replace(
+                                f"In {num}",
+                                f"'{error_command.get('name')}'",
+                            )
+
+                        ex.args = (error_string,)
+                        raise ex
+
+                    else:
+                        raise ex
             else:
                 self.logger.debug(
                     f"Detected no changes on {scope if scope is not None else 'global'}, skipping"


### PR DESCRIPTION
## About this pull request

Convert the indexes representing commands into command names

## Changes

- Wrapped `sync_all_commands`'s push into a try-except 
- Parse the discord error message for command indexes
- Determine which command corresponds to which index

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
