### PR TITLE
Fix KeyError in ComponentContext

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -324,9 +324,7 @@ class ComponentContext(InteractionContext):
         self.selected_options = None
 
         if self.component_type == 3:
-            self.selected_options = (
-                _json["data"]["values"] if "values" in _json["data"].keys() else []
-            )
+            self.selected_options = _json["data"].get("values", [])
 
     async def defer(self, hidden: bool = False, edit_origin: bool = False):
         """

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -321,7 +321,12 @@ class ComponentContext(InteractionContext):
             )
             self.component = self.origin_message.get_component(self.custom_id)
 
-        self.selected_options = _json["data"]["values"] if self.component_type == 3 else None
+        self.selected_options = None
+
+        if self.component_type == 3:
+            self.selected_options = (
+                _json["data"]["values"] if "values" in _json["data"].keys() else []
+            )
 
     async def defer(self, hidden: bool = False, edit_origin: bool = False):
         """


### PR DESCRIPTION
## About this pull request

Fix a KeyError raised when deselecting all choices of a Select with multiple choices

## Changes

Set the `selected_options` attribute to and empty list when the `value` key is missing

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
