### PR TITLE
Allow component response to be ignored

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -326,17 +326,18 @@ class ComponentContext(InteractionContext):
         if self.component_type == 3:
             self.selected_options = _json["data"].get("values", [])
 
-    async def defer(self, hidden: bool = False, edit_origin: bool = False):
+    async def defer(self, hidden: bool = False, edit_origin: bool = False, ignore: bool = False):
         """
         'Defers' the response, showing a loading state to the user
 
-        :param hidden: Whether the deferred response should be ephemeral . Default ``False``.
+        :param hidden: Whether the deferred response should be ephemeral. Default ``False``.
         :param edit_origin: Whether the type is editing the origin message. If ``False``, the deferred response will be for a follow up message. Defaults ``False``.
+        :param ignore: Whether to just ignore and not edit or send response. Using this can avoid showing interaction loading state. Default ``False``.
         """
         if self.deferred or self.responded:
             raise error.AlreadyResponded("You have already responded to this command!")
 
-        base = {"type": 6 if edit_origin else 5}
+        base = {"type": 6 if edit_origin or ignore else 5}
 
         if hidden:
             if edit_origin:
@@ -350,6 +351,9 @@ class ComponentContext(InteractionContext):
 
         await self._http.post_initial_response(base, self.interaction_id, self._token)
         self.deferred = True
+
+        if ignore:
+            self.responded = True
 
     async def send(
         self,

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -339,18 +339,26 @@ class ComponentContext(InteractionContext):
 
         base = {"type": 6 if edit_origin or ignore else 5}
 
+        if edit_origin and ignore:
+            raise error.IncorrectFormat(
+                "'edit_origin' and 'ignore' are mutually exclusive"
+            )
+
         if hidden:
             if edit_origin:
                 raise error.IncorrectFormat(
                     "'hidden' and 'edit_origin' flags are mutually exclusive"
                 )
-            base["data"] = {"flags": 64}
-            self._deferred_hidden = True
+            elif ignore:
+                self._deferred_hidden = True
+            else:
+                base["data"] = {"flags": 64}
+                self._deferred_hidden = True
 
         self._deferred_edit_origin = edit_origin
 
         await self._http.post_initial_response(base, self.interaction_id, self._token)
-        self.deferred = True
+        self.deferred = not ignore
 
         if ignore:
             self.responded = True

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -340,9 +340,7 @@ class ComponentContext(InteractionContext):
         base = {"type": 6 if edit_origin or ignore else 5}
 
         if edit_origin and ignore:
-            raise error.IncorrectFormat(
-                "'edit_origin' and 'ignore' are mutually exclusive"
-            )
+            raise error.IncorrectFormat("'edit_origin' and 'ignore' are mutually exclusive")
 
         if hidden:
             if edit_origin:


### PR DESCRIPTION
## About this pull request

This allows user to ignore component's response and prevent `ConponentContext.send` to work as unintended.
By using `ignore=True`, user can optionally use component's send method without loading state or whatever errors.
Example:
```py
@client.event
async def on_message(message: discord.Message):
    select = manage_components.create_button(style=3, label="Select", emoji="✅", custom_id=f"select{message.id}")
    row = manage_components.create_actionrow(select)

    msg = await message.reply("Using no option for `defer`.", components=[row])
    ctx = await manage_components.wait_for_component(client, msg, row)
    await ctx.defer()  # Now since we didn't respond to this interaction, user will see loading state.

    msg = await message.reply("Using `edit_origin=True` for `defer`.", components=[row])
    ctx = await manage_components.wait_for_component(client, msg, row)
    await ctx.defer(edit_origin=True)
    await ctx.send("But I want this as separate message!", hidden=True)  # However, this will neither be hidden nor separate message.

    msg = await message.reply("Using `ignore=True` for `defer`.", components=[row])
    ctx = await manage_components.wait_for_component(client, msg, row)
    await ctx.defer(ignore=True)
    await ctx.send("Now this is separate message!", hidden=True)  # This finally works as intended, without any errors.
```
![](https://cdn.discordapp.com/attachments/696562545489870861/869098909870485554/unknown.png)
(Second case message is edited.)

## Changes

Added `ignore` parameter to `ComponentContext.defer`.

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [x] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
