### PR TITLE
Restore `ctx.args` and `ctx.kwargs`

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -1202,6 +1202,9 @@ class SlashCommand:
         :param args: Args. Can be list or dict.
         """
         try:
+            if isinstance(args, dict):
+                ctx.kwargs = args
+                ctx.args = list(args.values())
             await func.invoke(ctx, **args)
         except Exception as ex:
             if not await self._handle_invoke_error(func, ctx, ex):


### PR DESCRIPTION
## About this pull request

Restores `ctx.args` and `ctx.kwargs` in `client.command_invoke`

## Changes

Added code to verify that `ctx.args` is a dict, and save it to `ctx.kwargs`, and the values to `ctx.args`

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [x] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #257 
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
