### PR TITLE
fix bug which causes arguments not getting properly parsed with slash commands

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -1202,7 +1202,7 @@ class SlashCommand:
         :param args: Args. Can be list or dict.
         """
         try:
-            await func.invoke(ctx, **args)
+            await func.invoke(ctx, *args)
         except Exception as ex:
             if not await self._handle_invoke_error(func, ctx, ex):
                 await self.on_slash_command_error(ctx, ex)


### PR DESCRIPTION
## About this pull request

fixes bug which causes slash commands not properly parse arguments

## Changes

changed one line to properly parse slash command arguments.

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [x] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
