### PR TITLE
Integrate Float and Mentionable enum + Add ctx.invoke()

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -392,6 +392,39 @@ class SlashContext(InteractionContext):
         else:
             return None
 
+    async def invoke(self, *args, **kwargs):
+        """
+        Invokes a command with the arguments given.\n
+        Similar to d.py's `ctx.invoke` function and documentation.\n
+
+        .. note::
+
+            This does not handle converters, checks, cooldowns, pre-invoke,
+            or after-invoke hooks in any matter. It calls the internal callback
+            directly as-if it was a regular function.
+
+            You must take care in passing the proper arguments when
+            using this function.
+
+        .. warning::
+            The first parameter passed **must** be the command being invoked.
+            While using `ctx.defer`, if the command invoked includes usage of that command, do not invoke
+            `ctx.defer` before calling this function. It can not defer twice.
+
+        :param args: Args for the command.
+        :param kwargs: Keyword args for the command.
+
+        :raises: :exc:`TypeError`
+        """
+
+        try:
+            command = args[0]
+        except IndexError:
+            raise TypeError("Missing command to invoke.") from None
+
+        ret = await self.slash.invoke_command(func=command, ctx=self, args=kwargs)
+        return ret
+
 
 class ComponentContext(InteractionContext):
     """

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import typing
 from contextlib import suppress
 from enum import IntEnum
 from inspect import iscoroutinefunction
@@ -456,6 +457,8 @@ class SlashCommandOptionType(IntEnum):
     USER = 6
     CHANNEL = 7
     ROLE = 8
+    MENTIONABLE = 9
+    FLOAT = 10
 
     @classmethod
     def from_type(cls, t: type):
@@ -465,6 +468,7 @@ class SlashCommandOptionType(IntEnum):
         :param t: The type or object to get a SlashCommandOptionType for.
         :return: :class:`.model.SlashCommandOptionType` or ``None``
         """
+
         if issubclass(t, str):
             return cls.STRING
         if issubclass(t, bool):
@@ -478,6 +482,16 @@ class SlashCommandOptionType(IntEnum):
             return cls.CHANNEL
         if issubclass(t, discord.abc.Role):
             return cls.ROLE
+        # Here's the issue. Typechecking for a **Union** somewhat differs per version (from 3.6.8+)
+        if (
+            hasattr(typing, "_GenericAlias")
+            and isinstance(t, typing._UnionGenericAlias)  # noqa
+            or not hasattr(typing, "_GenericAlias")
+            and isinstance(t, typing._Union)  # noqa
+        ):
+            return cls.MENTIONABLE
+        if issubclass(t, float):
+            return cls.FLOAT
 
 
 class SlashMessage(ComponentMessage):


### PR DESCRIPTION
## About this pull request

This implements `ctx.invoke()` and augments the ModelEnum with new type support (Mentionables and Floats)

Note (For further inquiries about failing CI builds), this fails because of commit 2fed36f from #262.

## Changes

- Added kwargs-only ctx.invoke()
- Added in Union/Float checking

## Checklist

- [X] I've run the `pre_push.py` script to format and lint code.
- [X] I've checked this pull request runs on `Python 3.6.X`.
- [X] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue: #271
- [X] This adds something new.
- [ ] There is/are breaking change(s).
- [X] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
