### PR TITLE
Fix Python 3.8 Union type checking.

### DIFF
--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import datetime
 import typing
 from typing import TYPE_CHECKING
@@ -369,7 +367,7 @@ class SlashContext(InteractionContext):
         super().__init__(_http=_http, _json=_json, _discord=_discord, logger=logger)
 
     @property
-    def slash(self) -> client.SlashCommand:
+    def slash(self) -> "client.SlashCommand":
         """
         Returns the associated SlashCommand object created during Runtime.
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -482,14 +482,13 @@ class SlashCommandOptionType(IntEnum):
             return cls.CHANNEL
         if issubclass(t, discord.abc.Role):
             return cls.ROLE
-        # Here's the issue. Typechecking for a **Union** somewhat differs per version (from 3.6.8+)
-
         if hasattr(typing, "_GenericAlias"):  # 3.7 onwards
-            if isinstance(t, typing._UnionGenericAlias):  # noqa
-                return cls.MENTIONABLE  # 3.9+
-            elif t.__origin__ is typing.Union:  # 3.7-3.8
+            # Easier than imports
+            if (
+                t.__origin__ is not None and t.__origin__ is typing.Union
+            ):  # proven in 3.7.8+, 3.8.6+, 3.9+ definitively
                 return cls.MENTIONABLE
-        else:  # py 3.6
+        if not hasattr(typing, "_GenericAlias"):  # py 3.6
             if isinstance(t, typing._Union):  # noqa
                 return cls.MENTIONABLE
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -483,13 +483,16 @@ class SlashCommandOptionType(IntEnum):
         if issubclass(t, discord.abc.Role):
             return cls.ROLE
         # Here's the issue. Typechecking for a **Union** somewhat differs per version (from 3.6.8+)
-        if (
-            hasattr(typing, "_GenericAlias")
-            and isinstance(t, typing._UnionGenericAlias)  # noqa
-            or not hasattr(typing, "_GenericAlias")
-            and isinstance(t, typing._Union)  # noqa
-        ):
-            return cls.MENTIONABLE
+
+        if hasattr(typing, "_GenericAlias"):  # 3.7 onwards
+            if isinstance(t, typing._UnionGenericAlias):  # noqa
+                return cls.MENTIONABLE  # 3.9+
+            elif t.__origin__ is typing.Union:  # 3.7-3.8
+                return cls.MENTIONABLE
+        else:  # py 3.6
+            if isinstance(t, typing._Union):  # noqa
+                return cls.MENTIONABLE
+
         if issubclass(t, float):
             return cls.FLOAT
 

--- a/discord_slash/model.py
+++ b/discord_slash/model.py
@@ -484,10 +484,10 @@ class SlashCommandOptionType(IntEnum):
             return cls.ROLE
         if hasattr(typing, "_GenericAlias"):  # 3.7 onwards
             # Easier than imports
-            if (
-                t.__origin__ is not None and t.__origin__ is typing.Union
-            ):  # proven in 3.7.8+, 3.8.6+, 3.9+ definitively
-                return cls.MENTIONABLE
+            if hasattr(t, "__origin__"):
+                if t.__origin__ is typing.Union:
+                    # proven in 3.7.8+, 3.8.6+, 3.9+ definitively
+                    return cls.MENTIONABLE
         if not hasattr(typing, "_GenericAlias"):  # py 3.6
             if isinstance(t, typing._Union):  # noqa
                 return cls.MENTIONABLE


### PR DESCRIPTION
## About this pull request

This fixes Python 3.8's Union type checking if someone uses the `MENTIONABLE` enum flag. 
This also fixes Python 3.6's `from future import __annotations__` check, as it doesn't exist in Python 3.6.x

## Changes

- Redo logic by splitting the isinstance/hasattr calls by major Python version
- Incorporate Python 3.8's Union check.
- Remove the annotation import and implement string annotations for the conflicting attr.

## Checklist

- [X] I've run the `pre_push.py` script to format and lint code.
- [X] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [X] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
