### PR TITLE
Increase Label/Description of selects to 100.

### DIFF
--- a/discord_slash/utils/manage_components.py
+++ b/discord_slash/utils/manage_components.py
@@ -174,8 +174,8 @@ def create_select_option(
     """
     emoji = emoji_to_dict(emoji)
 
-    if not len(label) or len(label) > 25:
-        raise IncorrectFormat("Label length should be between 1 and 25.")
+    if not len(label) or len(label) > 100:
+        raise IncorrectFormat("Label length should be between 1 and 100.")
     if not isinstance(value, str):
         value = str(value)
         logger.warning(
@@ -184,8 +184,8 @@ def create_select_option(
         )
     if not len(value) or len(value) > 100:
         raise IncorrectFormat("Value length should be between 1 and 100.")
-    if description is not None and len(description) > 50:
-        raise IncorrectFormat("Description length must be 50 or lower.")
+    if description is not None and len(description) > 100:
+        raise IncorrectFormat("Description length must be 100 or lower.")
 
     return {
         "label": label,


### PR DESCRIPTION
## About this pull request

This PR changes the Select Option label and description limits, see DDev post: https://discord.com/channels/613425648685547541/697138785317814292/873267579647578172

## Changes

Increases the limitation from 25 to 100 for labels and from 50 to 100 for descriptions.

## Checklist

- [X] I've run the `pre_push.py` script to format and lint code.
- [X] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
