### PR TITLE
Hotfix type-checking

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -1435,6 +1435,9 @@ class SlashCommand:
 
             selected_cmd = self.commands[to_use["data"]["name"]]
 
+            if type(selected_cmd) == dict:
+                return  # this is context dict storage.
+
             if selected_cmd._type != 1:
                 return  # If its a menu, ignore.
 

--- a/discord_slash/cog_ext.py
+++ b/discord_slash/cog_ext.py
@@ -205,14 +205,11 @@ def cog_context_menu(*, name: str, guild_ids: list = None, target: int = 1):
     """
 
     def wrapper(cmd):
-        # _obj = self.add_slash_command(
-        #    cmd,
-        #    name,
-        #    "",
-        #    guild_ids
-        # )
-
-        # This has to call both, as its a arg-less menu.
+        if name == "context":
+            raise IncorrectFormat(
+                "The name 'context' can not be used to register as a cog context menu,"
+                "as this conflicts with this lib's checks. Please use a different name instead."
+            )
 
         _cmd = {
             "default_permission": None,

--- a/discord_slash/context.py
+++ b/discord_slash/context.py
@@ -653,6 +653,7 @@ class MenuContext(InteractionContext):
         logger,
     ):
         super().__init__(_http=_http, _json=_json, _discord=_discord, logger=logger)
+        self.name = self.command = self.invoked_with = _json["data"]["name"]  # This exists.
         self.context_type = _json["type"]
         self._resolved = self.data["resolved"] if "resolved" in self.data.keys() else None
         self.target_message = None


### PR DESCRIPTION
## About this pull request

This PR type-checks commands if they're a dict or not. This is in question to: https://discord.com/channels/789032594456576001/789032934648447016/875832044268191764, and is more of a safeguard

This also introduces from SlashContext "ctx.name" for error checking.

## Changes

- Typechecks if the command selected points to the non-cog variant storage.
- Typechecks on cog creation name checking
- Adds `ctx.name` to MenuContext

## Checklist

- [X] I've run the `pre_push.py` script to format and lint code.
- [X] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
