### PR TITLE
Context menu example to README + indentation 4 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,26 @@ await ctx.send(components=[action_row])
 ### Advanced
 For more advanced use, please refer to our official documentation on [selects here.](https://discord-py-slash-command.readthedocs.io/en/latest/components.html#what-about-selects-dropdowns)
 
+## Context Menus
+This basic example shows how to add a message context menu.
+
+```py
+from discord_slash.context import MenuContext
+from discord_slash.model import ContextMenuType
+
+@slash.context_menu(target=ContextMenuType.MESSAGE,
+                    name="commandname",
+                    guild_ids=[789032594456576001])
+async def commandname(ctx: MenuContext):
+    await ctx.send(
+        content=f"Responded! The content of the message targeted: {ctx.target_message.content}",
+        hidden=True
+    )
+```
+
+### Advanced
+For more advanced use, please refer to our official documentation on [context menus here.](https://discord-py-slash-command.readthedocs.io/en/latest/gettingstarted.html#adding-context-menus)
+
 --------
 
 - The discord-interactions library is based off of API gateway events. If you are looking for a library webserver-based, please consider:

--- a/docs/gettingstarted.rst
+++ b/docs/gettingstarted.rst
@@ -367,10 +367,10 @@ Unlike ``manage_commands`` and ``manage_components``, you will have to use a dec
                       name="commandname",
                       guild_ids=[789032594456576001])
   async def commandname(ctx: MenuContext):
-    await ctx.send(
-      content=f"Responded! The content of the message targeted: {ctx.target_message.content}",
-      hidden=True
-    )
+      await ctx.send(
+          content=f"Responded! The content of the message targeted: {ctx.target_message.content}",
+          hidden=True
+      )
 
 The ``@slash.context_menu`` decorator takes in the context type as given (to either appear when you right-click on a user or when you right-click on a message) as well
 as the name of the command, and any guild IDs if given if you would like to make it applicable to only a guild. **We only accept connected names** for the time being,


### PR DESCRIPTION
## About this pull request

Adds a context menu example to the README.md, and changes the indentation of the example for the context menu in order for the examples' indentations to be consistent with each other.

## Changes

- README.md
- Getting Started docs

## Checklist

- [ ] I've run the `pre_push.py` script to format and lint code.
- [ ] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [x] This is not a code change. (README, docs, etc.)
