### PR TITLE
Allow multiple context menus

### DIFF
--- a/discord_slash/client.py
+++ b/discord_slash/client.py
@@ -303,7 +303,7 @@ class SlashCommand:
                             }
                             if y in selected.permissions:
                                 command_dict["permissions"][y] = selected.permissions[y]
-                            wait[y][x] = copy.deepcopy(command_dict)
+                            wait[y][_x] = copy.deepcopy(command_dict)
                     else:
                         if "global" not in wait:
                             wait["global"] = {}
@@ -314,7 +314,7 @@ class SlashCommand:
                             "permissions": selected.permissions or {},
                             "type": selected._type,
                         }
-                        wait["global"][x] = copy.deepcopy(command_dict)
+                        wait["global"][_x] = copy.deepcopy(command_dict)
 
                 continue
 


### PR DESCRIPTION
## About this pull request

Allow multiple context menus

## Changes

lines 317 and 306 should have had `_x` instead of `x`, as shown by Blue#6405 in #lib-discussion

## Checklist

- [x] I've run the `pre_push.py` script to format and lint code.
- [x] I've checked this pull request runs on `Python 3.6.X`.
- [ ] This fixes something in [Issues](https://github.com/eunwoo1104/discord-py-slash-command/issues).
    - Issue:
- [ ] This adds something new.
- [ ] There is/are breaking change(s).
- [ ] (If required) Relevant documentation has been updated/added.
- [ ] This is not a code change. (README, docs, etc.)
